### PR TITLE
Feature/upbit (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,31 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation('org.springframework.boot:spring-boot-starter-web') {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+    }
+    implementation 'org.springframework.boot:spring-boot-starter-undertow'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'com.auth0:java-jwt:3.18.2' // upbit api 헤더 생성을 위함
+
+    implementation 'com.h2database:h2'
+    implementation ('it.ozimov:embedded-redis:0.7.3'){
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    //fixme resdoc
+
+    // test
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/httpRequests/adminHttpRequests.http
+++ b/httpRequests/adminHttpRequests.http
@@ -1,0 +1,16 @@
+POST localhost:8080/admin/command/start
+Content-Type: application/json
+
+{
+  "coinType": "ETHEREUM",
+  "coinExchangeType": "UPBIT",
+  "tradingTerm": "SCALPING",
+  "strategyCode": "RSI"
+}
+
+
+###
+POST localhost:8080/admin/command/stop
+Content-Type: application/json
+
+###

--- a/src/main/java/com/dingdongdeng/coinautotrading/admin/controller/AdminController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/admin/controller/AdminController.java
@@ -1,0 +1,27 @@
+package com.dingdongdeng.coinautotrading.admin.controller;
+
+import com.dingdongdeng.coinautotrading.admin.model.CommandRequest;
+import com.dingdongdeng.coinautotrading.admin.model.type.Command;
+import com.dingdongdeng.coinautotrading.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/command/{command}")
+    public String command(@PathVariable String command, @RequestBody CommandRequest request) {
+        adminService.command(Command.of(command), request);
+        return "execute command : " + command + "/" + request;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/admin/controller/ControllerExceptionHandler.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/admin/controller/ControllerExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.dingdongdeng.coinautotrading.admin.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.dingdongdeng.coinautotrading.admin.controller")
+public class ControllerExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public String exceptionHandler(Exception e) {
+        log.error(e.getMessage(), e);
+        return "occured exception : " + e.getMessage();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/admin/model/CommandRequest.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/admin/model/CommandRequest.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.admin.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.StrategyCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class CommandRequest {
+
+    private CoinType coinType;
+    private CoinExchangeType coinExchangeType;
+    private TradingTerm tradingTerm;
+    private StrategyCode strategyCode;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/admin/model/type/Command.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/admin/model/type/Command.java
@@ -1,0 +1,17 @@
+package com.dingdongdeng.coinautotrading.admin.model.type;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+public enum Command {
+    START,
+    STOP,
+    ;
+
+    public static Command of(String name) {
+        return Arrays.stream(Command.values())
+            .filter(type -> type.name().equalsIgnoreCase(name))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(name));
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/admin/service/AdminService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/admin/service/AdminService.java
@@ -1,0 +1,38 @@
+package com.dingdongdeng.coinautotrading.admin.service;
+
+import com.dingdongdeng.coinautotrading.admin.model.CommandRequest;
+import com.dingdongdeng.coinautotrading.admin.model.type.Command;
+import com.dingdongdeng.coinautotrading.trading.autotrading.model.AutoTradingStartParam;
+import com.dingdongdeng.coinautotrading.trading.autotrading.service.AutoTradingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AdminService {
+
+    private final AutoTradingService autoTradingService;
+
+    public void command(Command command, CommandRequest request) {
+
+        if (command == Command.STOP) {
+            autoTradingService.stop();
+            return;
+        }
+
+        if (command == Command.START) {
+            autoTradingService.start(makeAutoTradingStartParam(request));
+        }
+    }
+
+    private AutoTradingStartParam makeAutoTradingStartParam(CommandRequest request) {
+        return AutoTradingStartParam.builder()
+            .coinType(request.getCoinType())
+            .coinExchangeType(request.getCoinExchangeType())
+            .tradingTerm(request.getTradingTerm())
+            .strategyCode(request.getStrategyCode())
+            .build();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/ApplicationConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/ApplicationConfig.java
@@ -1,0 +1,12 @@
+package com.dingdongdeng.coinautotrading.common;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableConfigurationProperties
+@EnableAsync
+@Configuration
+public class ApplicationConfig {
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncConfig.java
@@ -1,0 +1,30 @@
+package com.dingdongdeng.coinautotrading.common.async;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(10);
+        taskExecutor.setQueueCapacity(20);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setThreadNamePrefix("Executor-");
+        taskExecutor.setTaskDecorator(new AsyncTaskDecorator());
+
+        return taskExecutor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncExceptionHandler.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.dingdongdeng.coinautotrading.common.async;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable e, Method method, Object... params) {
+        log.error(e.getMessage(), e);
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncTaskDecorator.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/async/AsyncTaskDecorator.java
@@ -1,0 +1,17 @@
+package com.dingdongdeng.coinautotrading.common.async;
+
+import com.dingdongdeng.coinautotrading.common.filter.LoggingUtils;
+import java.util.Map;
+import org.springframework.core.task.TaskDecorator;
+
+public class AsyncTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable task) {
+        Map<String, String> context = LoggingUtils.getLogData();
+        return () -> {
+            LoggingUtils.setLogData(context);
+            task.run();
+        };
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/client/Client.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/client/Client.java
@@ -1,0 +1,101 @@
+package com.dingdongdeng.coinautotrading.common.client;
+
+import com.dingdongdeng.coinautotrading.common.client.exception.ApiResponseException;
+import com.dingdongdeng.coinautotrading.common.client.util.QueryParamsConverter;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class Client {
+
+    private final WebClient webClient;
+    private final QueryParamsConverter queryParamsConverter;
+
+    protected <T> T get(String path, Class<T> clazz, HttpHeaders headers) {
+        return get(path, null, clazz, headers);
+    }
+
+    protected <T> T get(String path, Object params, Class<T> clazz, HttpHeaders headers) {
+        return get(path, queryParamsConverter.convertMap(params), clazz, headers);
+    }
+
+    protected <T> T get(String path, MultiValueMap<String, String> params, Class<T> clazz, HttpHeaders headers) {
+        return responseHandle(
+            () -> webClient.get()
+                .uri(uriBuilder -> uriBuilder.path(path).queryParams(params).build())
+                .headers(headers_ -> headers_.addAll(headers))
+                .retrieve()
+                .bodyToMono(clazz)
+                .block()
+        );
+    }
+
+    protected <T> T get(String path, ParameterizedTypeReference<T> parameterizedTypeReference, HttpHeaders headers) {
+        return get(path, null, parameterizedTypeReference, headers);
+    }
+
+    protected <T> T get(String path, Object params, ParameterizedTypeReference<T> parameterizedTypeReference, HttpHeaders headers) {
+        return get(path, queryParamsConverter.convertMap(params), parameterizedTypeReference, headers);
+    }
+
+    protected <T> T get(String path, MultiValueMap<String, String> params, ParameterizedTypeReference<T> parameterizedTypeReference, HttpHeaders headers) {
+        return responseHandle(
+            () -> webClient.get()
+                .uri(uriBuilder -> uriBuilder.path(path).queryParams(params).build())
+                .headers(headers_ -> headers_.addAll(headers))
+                .retrieve()
+                .bodyToMono(parameterizedTypeReference)
+                .block()
+        );
+    }
+
+    protected <T> T post(String path, Object body, Class<T> clazz, HttpHeaders headers) {
+        return responseHandle(
+            () -> webClient.post()
+                .uri(path)
+                .headers(headers_ -> headers_.addAll(headers))
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(clazz)
+                .block()
+        );
+    }
+
+    protected <T> T put(String path, Object body, Class<T> clazz) {
+        return null;
+    }
+
+    protected <T> T delete(String path, Object params, Class<T> clazz, HttpHeaders headers) {
+        return delete(path, queryParamsConverter.convertMap(params), clazz, headers);
+    }
+
+    protected <T> T delete(String path, MultiValueMap params, Class<T> clazz, HttpHeaders headers) {
+        return responseHandle(
+            () -> webClient.delete()
+                .uri(uriBuilder -> uriBuilder.path(path).queryParams(params).build())
+                .headers(headers_ -> headers_.addAll(headers))
+                .retrieve()
+                .bodyToMono(clazz)
+                .block()
+        );
+    }
+
+    private <T> T responseHandle(Supplier<T> request) {
+        try {
+            return request.get();
+        } catch (WebClientResponseException e) {
+            throw new ApiResponseException(e.getStatusCode(), e.getResponseBodyAsString(StandardCharsets.UTF_8), e);
+        } catch (Exception e) {
+            throw new ApiResponseException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/client/config/WebClientConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/client/config/WebClientConfig.java
@@ -1,0 +1,37 @@
+package com.dingdongdeng.coinautotrading.common.client.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+public abstract class WebClientConfig {
+
+    protected WebClient makeWebClient(String baseUrl, int readTimeout, int connectionTimeout) {
+        HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionTimeout)
+            .responseTimeout(Duration.ofMillis(5000))
+            .doOnConnected(conn ->
+                conn.addHandlerLast(new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS))
+                    .addHandlerLast(new WriteTimeoutHandler(5000, TimeUnit.MILLISECONDS)))
+            //.wiretap("reactor.netty.http.client.HttpClient", LogLevel.INFO, AdvancedByteBufFormat.TEXTUAL)
+            ;
+
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeaders(httpHeaders -> {
+                httpHeaders.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            })
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .filters(exchangeFilterFunctions -> {
+                exchangeFilterFunctions.add(new WebClientLogger());
+            })
+            .build();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/client/config/WebClientLogger.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/client/config/WebClientLogger.java
@@ -1,0 +1,94 @@
+package com.dingdongdeng.coinautotrading.common.client.config;
+
+import com.dingdongdeng.coinautotrading.common.filter.LoggingUtils;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpRequestDecorator;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class WebClientLogger implements ExchangeFilterFunction {
+
+    // https://stackoverflow.com/questions/46154994/how-to-log-spring-5-webclient-call
+    @Override
+    public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+
+        String pairKey = UUID.randomUUID().toString().substring(0, 7);
+        StringBuilder logReqBuilder = new StringBuilder();
+        logReqBuilder
+            .append("\n")
+            .append("webclient request ::: " + pairKey).append("\n")
+            .append("url : ").append(request.url()).append("\n")
+            .append("method : ").append(request.method()).append("\n")
+            .append("headers : ").append(request.headers()).append("\n");
+        BodyInserter<?, ? super ClientHttpRequest> originalBodyInserter = request.body();
+
+        Map<String, String> contextMap = LoggingUtils.getLogData();
+
+        ClientRequest loggingClientRequest = ClientRequest.from(request)
+            .body((outputMessage, context) -> {
+                ClientHttpRequestDecorator loggingOutputMessage = new ClientHttpRequestDecorator(outputMessage) {
+                    private final AtomicBoolean alreadyLogged = new AtomicBoolean(false);
+
+                    @Override
+                    public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+                        boolean needToLog = alreadyLogged.compareAndSet(false, true);
+                        if (needToLog) {
+                            body = DataBufferUtils.join(body)
+                                .doOnNext(content -> {
+                                    LoggingUtils.setLogData(contextMap);
+                                    logReqBuilder.append("body : ").append(content.toString(StandardCharsets.UTF_8)).append("\n");
+                                    log.info(logReqBuilder.toString());
+                                });
+                        }
+                        return super.writeWith(body);
+                    }
+
+                    @Override
+                    public Mono<Void> setComplete() { // This is for requests with no body (e.g. GET).
+                        boolean needToLog = alreadyLogged.compareAndSet(false, true);
+                        if (needToLog) {
+                            LoggingUtils.setLogData(contextMap);
+                            log.info(logReqBuilder.toString());
+                        }
+                        return super.setComplete();
+                    }
+                };
+
+                return originalBodyInserter.insert(loggingOutputMessage, context);
+            })
+            .build();
+
+        return next.exchange(loggingClientRequest)
+            .map(clientResponse -> clientResponse.mutate()
+                .body(f -> {
+                    LoggingUtils.setLogData(contextMap);
+                    StringBuilder logResBuilder = new StringBuilder();
+                    logResBuilder
+                        .append("\n")
+                        .append("webclient response ::: " + pairKey).append("\n")
+                        .append("status : ").append(clientResponse.statusCode()).append("\n")
+                        .append("headers : ").append(clientResponse.headers().asHttpHeaders().toString()).append("\n");
+                    logResBuilder.append("body : ");
+                    return f.map(dataBuffer -> {
+                        logResBuilder.append(dataBuffer.toString(StandardCharsets.UTF_8));
+                        return dataBuffer;
+                    }).doOnComplete(() -> log.info(logResBuilder.toString()));
+                })
+                .build()
+            );
+
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/client/exception/ApiResponseException.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/client/exception/ApiResponseException.java
@@ -1,0 +1,23 @@
+package com.dingdongdeng.coinautotrading.common.client.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+@ToString
+@Getter
+public class ApiResponseException extends RuntimeException {
+
+    private HttpStatus httpStatus;
+    private String body;
+
+    public ApiResponseException(HttpStatus status, String body, Throwable cause) {
+        super(cause);
+        this.httpStatus = status;
+        this.body = body;
+    }
+
+    public ApiResponseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/client/util/QueryParamsConverter.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/client/util/QueryParamsConverter.java
@@ -1,0 +1,53 @@
+package com.dingdongdeng.coinautotrading.common.client.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RequiredArgsConstructor
+@Component
+public class QueryParamsConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public MultiValueMap<String, String> convertMap(Object object) {
+        try {
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            if (Objects.isNull(object)) {
+                return params;
+            }
+            Map<String, Object> map = objectMapper.convertValue(object, new TypeReference<>() {
+            });
+
+            map.forEach((key, value) -> {
+                if (value instanceof List) { //fixme 개선필요
+                    List<String> str = (List<String>) ((List) value).stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.toList());
+                    str.forEach(s -> params.add(key + "", s));
+                    return;
+                }
+                params.add(key, String.valueOf(value));
+            });
+            return params;
+        } catch (Exception e) {
+            throw new IllegalStateException("fail generate query params", e);
+        }
+    }
+
+    public String convertStr(Object object) {
+        return UriComponentsBuilder.fromUriString("")
+            .queryParams(convertMap(object))
+            .build()
+            //.encode()
+            .toUriString();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/domain/RepositoryService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/domain/RepositoryService.java
@@ -1,0 +1,12 @@
+package com.dingdongdeng.coinautotrading.common.domain;
+
+import java.util.List;
+
+public interface RepositoryService<T, ID> {
+
+    T findById(ID id);
+
+    T save(T entity);
+
+    List<T> saveAll(Iterable<T> iterable);
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/filter/FilterConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/filter/FilterConfig.java
@@ -1,0 +1,17 @@
+package com.dingdongdeng.coinautotrading.common.filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class FilterConfig implements WebMvcConfigurer {
+
+    @Bean
+    public FilterRegistrationBean getFilterRegistrationBean() {
+        FilterRegistrationBean registrationBean = new FilterRegistrationBean(new LoggingFilter());
+        registrationBean.addUrlPatterns("/*");
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/filter/LoggingFilter.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/filter/LoggingFilter.java
@@ -1,0 +1,101 @@
+package com.dingdongdeng.coinautotrading.common.filter;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.springframework.web.util.WebUtils;
+
+@Slf4j
+public class LoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+
+        LoggingUtils.trace();
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+
+        log.info(makeloggingString(wrappingRequest)); // logging request
+        chain.doFilter(wrappingRequest, wrappingResponse);
+        log.info(makeLoggingString(wrappingResponse)); // logging response
+
+        wrappingResponse.copyBodyToResponse();
+    }
+
+    private String makeloggingString(ContentCachingRequestWrapper request) {
+        return new StringBuilder()
+            .append("\n")
+            .append("request ::: ").append("\n")
+            .append("url : ").append(request.getRequestURL()).append("\n")
+            .append("method : ").append(request.getMethod()).append("\n")
+            .append("headers : ").append(getHeaders(request)).append("\n")
+            .append("body : ").append(getRequestBody(request))
+            .toString();
+    }
+
+    private String makeLoggingString(ContentCachingResponseWrapper response) {
+        return new StringBuilder()
+            .append("\n")
+            .append("response ::: ").append("\n")
+            .append("status : ").append(response.getStatus()).append("\n")
+            .append("body : ").append(getResponseBody(response))
+            .toString();
+    }
+
+
+    private Map getHeaders(HttpServletRequest request) {
+        Map headerMap = new HashMap<>();
+
+        Enumeration headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = (String) headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+
+    private String getRequestBody(ContentCachingRequestWrapper request) {
+        ContentCachingRequestWrapper wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        if (wrapper != null) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                try {
+                    return new String(buf, 0, buf.length, wrapper.getCharacterEncoding());
+                } catch (UnsupportedEncodingException e) {
+                    return " - ";
+                }
+            }
+        }
+        return " - ";
+    }
+
+    private String getResponseBody(final HttpServletResponse response) {
+        try {
+            String payload = null;
+            ContentCachingResponseWrapper wrapper =
+                WebUtils.getNativeResponse(response, ContentCachingResponseWrapper.class);
+            if (wrapper != null) {
+                byte[] buf = wrapper.getContentAsByteArray();
+                if (buf.length > 0) {
+                    payload = new String(buf, 0, buf.length, wrapper.getCharacterEncoding());
+                    wrapper.copyBodyToResponse();
+                }
+            }
+            return null == payload ? " - " : payload;
+        } catch (Exception e) {
+            log.error("fail response logging : " + e.getMessage(), e);
+            return "";
+        }
+
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/filter/LoggingUtils.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/filter/LoggingUtils.java
@@ -1,0 +1,39 @@
+package com.dingdongdeng.coinautotrading.common.filter;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.experimental.UtilityClass;
+import org.slf4j.MDC;
+
+@UtilityClass
+public class LoggingUtils {
+
+    public static void trace() {
+        clear();
+        put("traceId", UUID.randomUUID().toString().replaceAll("-", "").substring(0, 10));
+    }
+
+    public static void put(String key, String value) {
+        MDC.put(key, value);
+    }
+
+    public static String get(String key) {
+        return MDC.get(key);
+    }
+
+    public static Map<String, String> getLogData() {
+        return MDC.getCopyOfContextMap();
+    }
+
+    public static void setLogData(Map<String, String> contextMap) {
+        if (Objects.nonNull(contextMap)) {
+            MDC.setContextMap(contextMap);
+        }
+    }
+
+    public static void clear() {
+        MDC.clear();
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/redis/EmbeddedRedisConfig.java
@@ -1,0 +1,39 @@
+package com.dingdongdeng.coinautotrading.common.redis;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import redis.embedded.RedisServer;
+
+@Slf4j
+@Configuration
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+    @Value("${spring.redis.port}")
+    private int port;
+    private RedisServer redisServer;
+
+    public EmbeddedRedisConfig(@Value("${spring.redis.port}") int port, @Value("${spring.redis.host}") String host) {
+        this.host = host;
+        this.port = port;
+        this.redisServer = new RedisServer(port);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        try {
+            redisServer.start();
+        } catch (Exception ige) {
+            log.error(ige.getMessage());
+        }
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        redisServer.stop();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/redis/RedisConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/redis/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.dingdongdeng.coinautotrading.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/redis/RedisService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/redis/RedisService.java
@@ -1,0 +1,28 @@
+package com.dingdongdeng.coinautotrading.common.redis;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final int DEFAULT_EXPIRE_DAYS = 3;
+
+    public void set(String key, String value) {
+        redisTemplate.opsForValue().set(key, value);
+        redisTemplate.expire(key, DEFAULT_EXPIRE_DAYS, TimeUnit.DAYS);
+    }
+
+    public String get(String key) {
+        return (String) (redisTemplate.opsForValue().get(key));
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/CandleUnit.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/CandleUnit.java
@@ -1,0 +1,31 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CandleUnit {
+    UNIT_1M("1분 봉", UnitType.MIN, 1),
+    UNIT_3M("3분 봉", UnitType.MIN, 3),
+
+    UNIT_5M("5분 봉", UnitType.MIN, 5),
+    UNIT_10M("10분 봉", UnitType.MIN, 10),
+    UNIT_15M("15분 봉", UnitType.MIN, 15),
+    UNIT_30M("30분 봉", UnitType.MIN, 30),
+    UNIT_60M("60분 봉", UnitType.MIN, 60),
+    UNIT_1D("1일 봉", UnitType.DAY, 1),
+    UNIT_1W("1주 봉", UnitType.WEEK, 1),
+    ;
+
+    private String desc;
+    private UnitType unitType;
+    private int size;
+
+    public enum UnitType {
+        MIN,
+        DAY,
+        WEEK,
+        ;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/CoinExchangeType.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/CoinExchangeType.java
@@ -1,0 +1,17 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+public enum CoinExchangeType {
+    UPBIT,
+    BITHUM,
+    ;
+
+    public static CoinExchangeType of(String name) {
+        return Arrays.stream(CoinExchangeType.values())
+            .filter(type -> type.name().equalsIgnoreCase(name))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(name));
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/CoinType.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/CoinType.java
@@ -1,0 +1,12 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CoinType {
+    ETHEREUM("이더리움"),
+    ;
+    private String desc;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/OrderState.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/OrderState.java
@@ -1,0 +1,15 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderState {
+    WAIT("체결 대기"),
+    WATCH("예약 주문 대기"),
+    DONE("체결 완료"),
+    CANCEL("주문 취소"),
+    ;
+    private String desc;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/OrderType.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/OrderType.java
@@ -1,0 +1,8 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+public enum OrderType {
+    BUY,
+    SELL,
+    CANCEL,
+    ;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/PriceType.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/PriceType.java
@@ -1,0 +1,8 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+public enum PriceType {
+    LIMIT_PRICE,
+    SELLING_MARKET_PRICE,
+    BUYING_MARKET_PRICE,
+    ;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/common/type/TradingTerm.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/common/type/TradingTerm.java
@@ -1,0 +1,17 @@
+package com.dingdongdeng.coinautotrading.common.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TradingTerm {
+    EXTREAM_SCALPING("극한의 스캘핑", CandleUnit.UNIT_1M),
+    SCALPING("스캘핑", CandleUnit.UNIT_15M),
+    DAY("데이", CandleUnit.UNIT_1D),
+    SWING("스윙", CandleUnit.UNIT_1W),
+    ;
+
+    private String desc;
+    private CandleUnit candleUnit; // 참조할 차트의 캔들 사이즈(5분 봉, 15분 봉,
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/entity/Candle.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/entity/Candle.java
@@ -1,0 +1,70 @@
+package com.dingdongdeng.coinautotrading.domain.entity;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "candle")
+public class Candle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "candle_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coin_exchange_type")
+    private CoinExchangeType coinExchangeType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coin_type")
+    private CoinType coinType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "candle_unit")
+    private CandleUnit candleUnit;
+
+    @Column(name = "candle_date_time_utc")
+    private LocalDateTime candleDateTimeUtc;
+
+    @Column(name = "candle_date_time_kst")
+    private LocalDateTime candleDateTimeKst;
+
+    @Column(name = "opening_price")
+    private Double openingPrice; // 시가
+
+    @Column(name = "high_price")
+    private Double highPrice; // 고가
+
+    @Column(name = "low_price")
+    private Double lowPrice; // 저가
+
+    @Column(name = "trade_price")
+    private Double tradePrice; // 종가
+
+    @Column(name = "candle_acc_trade_price")
+    private Double candleAccTradePrice; // 누적 거래 금액
+
+    @Column(name = "candle_acc_trade_volume")
+    private Double candleAccTradeVolume; // 누적 거래량
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/entity/TradeOrder.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/entity/TradeOrder.java
@@ -1,0 +1,86 @@
+package com.dingdongdeng.coinautotrading.domain.entity;
+
+import com.dingdongdeng.coinautotrading.common.type.OrderState;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "trade_order")
+public class TradeOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trade_order_id")
+    private Long id;
+
+    @Column(name = "order_id", columnDefinition = "VARCHAR(30) COMMENT '주문 번호'")
+    private String orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_type", columnDefinition = "VARCHAR(30) DEFAULT 'guest' COMMENT '주문 종류'")
+    private OrderType orderType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "price_type", columnDefinition = "VARCHAR(30) DEFAULT 'guest' COMMENT '주문 방식'")
+    private PriceType priceType;
+
+    @Column(name = "price", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '주문 당시 화폐 가격'")
+    private Double price;
+
+    @Column(name = "avg_price", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '체결 가격의 평균가'")
+    private Double avgPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_state", columnDefinition = "VARCHAR(30) DEFAULT 'WAIT' COMMENT '주문 상태'")
+    private OrderState orderState;
+
+    @Column(name = "market", columnDefinition = "VARCHAR(30) DEFAULT 'guest' COMMENT '이름'")
+    private String market;
+
+    @Column(name = "created_at", columnDefinition = "VARCHAR(30) DEFAULT 'guest' COMMENT '주문 생성 시간'")
+    private String createdAt;
+
+    @Column(name = "volume", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '사용자가 입력한 주문 양'")
+    private Double volume;
+
+    @Column(name = "remaining_volume", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '체결 후 남은 주문 양'")
+    private Double remainingVolume;
+
+    @Column(name = "reserved_fee", columnDefinition = "DOUBLE  DEFAULT 0 COMMENT '수수료로 예약된 비용'")
+    private Double reservedFee;
+
+    @Column(name = "remaining_fee", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '남은 수수료'")
+    private Double remainingFee;
+
+    @Column(name = "paid_fee", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '사용된 수수료'")
+    private Double paidFee;
+
+    @Column(name = "locked", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '거래에 사용중인 비용'")
+    private Double locked;
+
+    @Column(name = "executed_volume", columnDefinition = "DOUBLE DEFAULT 0 COMMENT '체결된 양'")
+    private Double executedVolume;
+
+    @Column(name = "trade_count", columnDefinition = "VARCHAR(30) DEFAULT 0 COMMENT '해당 주문에 걸린 체결 수'")
+    private Long tradeCount;
+
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/repository/CandleRepository.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/repository/CandleRepository.java
@@ -1,0 +1,24 @@
+package com.dingdongdeng.coinautotrading.domain.repository;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.domain.entity.Candle;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CandleRepository extends JpaRepository<Candle, Long> {
+
+    @Query("select c from Candle c "
+        + "where c.coinType = :coinType and c.candleUnit = :candleUnit and c.coinExchangeType = :coinExchangeType "
+        + "order by c.candleDateTimeKst desc ")
+    List<Candle> findAllCandleList(
+        @Param("coinType") CoinType coinType,
+        @Param("candleUnit") CandleUnit candleUnit,
+        @Param("coinExchangeType") CoinExchangeType coinExchangeType,
+        Pageable pageable
+    );
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/repository/TradeOrderRepository.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/repository/TradeOrderRepository.java
@@ -1,0 +1,8 @@
+package com.dingdongdeng.coinautotrading.domain.repository;
+
+import com.dingdongdeng.coinautotrading.domain.entity.TradeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeOrderRepository extends JpaRepository<TradeOrder, Long> {
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/service/CandleService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/service/CandleService.java
@@ -1,0 +1,42 @@
+package com.dingdongdeng.coinautotrading.domain.service;
+
+import com.dingdongdeng.coinautotrading.common.domain.RepositoryService;
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.domain.entity.Candle;
+import com.dingdongdeng.coinautotrading.domain.repository.CandleRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Component
+public class CandleService implements RepositoryService<Candle, Long> {
+
+    private final CandleRepository repository;
+
+    public Candle findById(Long id) {
+        return repository.findById(id).orElse(new Candle());
+    }
+
+    public Candle save(Candle entity) {
+        return repository.save(entity);
+    }
+
+    public List<Candle> saveAll(Iterable<Candle> iterable) {
+        return repository.saveAll(iterable);
+    }
+
+    public Optional<Candle> findOneLastCandle(CoinExchangeType coinExchangeType, CoinType coinType, CandleUnit candleUnit) {
+        return repository.findAllCandleList(coinType, candleUnit, coinExchangeType, PageRequest.of(0, 1))
+            .stream()
+            .findFirst();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/domain/service/TradeOrderService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/domain/service/TradeOrderService.java
@@ -1,0 +1,31 @@
+package com.dingdongdeng.coinautotrading.domain.service;
+
+import com.dingdongdeng.coinautotrading.common.domain.RepositoryService;
+import com.dingdongdeng.coinautotrading.domain.entity.TradeOrder;
+import com.dingdongdeng.coinautotrading.domain.repository.TradeOrderRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Component
+public class TradeOrderService implements RepositoryService<TradeOrder, Long> {
+
+    private final TradeOrderRepository repository;
+
+    public TradeOrder findById(Long id) {
+        return repository.findById(id).orElse(new TradeOrder());
+    }
+
+    public TradeOrder save(TradeOrder tradeOrder) {
+        return repository.save(tradeOrder);
+    }
+
+    public List<TradeOrder> saveAll(Iterable<TradeOrder> iterable) {
+        return repository.saveAll(iterable);
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitClient.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitClient.java
@@ -1,0 +1,89 @@
+package com.dingdongdeng.coinautotrading.exchange.client;
+
+import com.dingdongdeng.coinautotrading.common.client.Client;
+import com.dingdongdeng.coinautotrading.common.client.util.QueryParamsConverter;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.CandleRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.MarketCodeRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderBookRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderCancelRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderChanceRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderInfoListRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderInfoRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.TickerRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.AccountsResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.CandleResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.MarketCodeResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderBookResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderCancelResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrdersChanceResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.TickerResponse;
+import java.util.List;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class UpbitClient extends Client {
+
+    private final UpbitTokenGenerator tokenGenerator;
+
+    public UpbitClient(WebClient upbitWebClient, UpbitTokenGenerator tokenGenerator, QueryParamsConverter queryParamsConverter) {
+        super(upbitWebClient, queryParamsConverter);
+        this.tokenGenerator = tokenGenerator;
+    }
+
+    public List<AccountsResponse> getAccounts() {
+        return get("/v1/accounts", new ParameterizedTypeReference<>() {
+        }, makeHeaders(null));
+    }
+
+    public OrdersChanceResponse getOrdersChance(OrderChanceRequest request) {
+        return get("/v1/orders/chance", request, OrdersChanceResponse.class, makeHeaders(request));
+    }
+
+    public List<MarketCodeResponse> getMarketList(MarketCodeRequest request) {
+        return get("/v1/market/all", request, new ParameterizedTypeReference<>() {
+        }, makeHeaders(request));
+    }
+
+    public OrderResponse getOrderInfo(OrderInfoRequest request) {
+        return get("/v1/order", request, OrderResponse.class, makeHeaders(request));
+    }
+
+    public List<OrderResponse> getOrderInfoList(OrderInfoListRequest request) {
+        return get("/v1/orders", request, new ParameterizedTypeReference<>() {
+        }, makeHeaders(request));
+    }
+
+    public OrderResponse order(OrderRequest request) {
+        return post("/v1/orders", request, OrderResponse.class, makeHeaders(request));
+    }
+
+    public OrderCancelResponse orderCancel(OrderCancelRequest request) {
+        return delete("/v1/order", request, OrderCancelResponse.class, makeHeaders(request));
+    }
+
+    public List<CandleResponse> getMinuteCandle(CandleRequest request) {
+        return get("/v1/candles/minutes/" + request.getUnit(), request, new ParameterizedTypeReference<>() {
+        }, makeHeaders(request));
+    }
+
+    public List<OrderBookResponse> getOrderBook(OrderBookRequest request) {
+        return get("/v1/orderbook", request, new ParameterizedTypeReference<>() {
+        }, makeHeaders(request));
+    }
+
+    public List<TickerResponse> getTicker(TickerRequest request) {
+        return get("/v1/ticker", request, new ParameterizedTypeReference<>() {
+        }, makeHeaders(request));
+    }
+
+    private HttpHeaders makeHeaders(Object request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", tokenGenerator.makeToken(request));
+        return headers;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitTokenGenerator.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitTokenGenerator.java
@@ -1,0 +1,54 @@
+package com.dingdongdeng.coinautotrading.exchange.client;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.dingdongdeng.coinautotrading.common.client.util.QueryParamsConverter;
+import com.dingdongdeng.coinautotrading.exchange.client.config.UpbitClientResourceProperties;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class UpbitTokenGenerator {
+
+    private final UpbitClientResourceProperties properties;
+    private final QueryParamsConverter queryParamsConverter;
+
+    public String makeToken(Object request) {
+        String accessKey = properties.getAccessKey();
+        String secretKey = properties.getSecretKey();
+
+        Algorithm algorithm = Algorithm.HMAC256(secretKey);
+        JWTCreator.Builder jwtBuilder = JWT.create()
+            .withClaim("access_key", accessKey)
+            .withClaim("nonce", UUID.randomUUID().toString());
+
+        if (Objects.nonNull(request)) {
+            jwtBuilder
+                .withClaim("query_hash", makeQueryHash(request))
+                .withClaim("query_hash_alg", "SHA512");
+        }
+
+        return "Bearer " + jwtBuilder.sign(algorithm);
+    }
+
+    private String makeQueryHash(Object request) {
+        try {
+            String params = queryParamsConverter.convertStr(request).substring(1); //?name=aaa&age=12 형태에서 ? 제거
+            log.info("upbit query hash by params : {}", params);
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
+            md.update(params.getBytes("UTF-8"));
+
+            return String.format("%0128x", new BigInteger(1, md.digest()));
+        } catch (Exception e) {
+            throw new RuntimeException("fail make query hash", e);
+        }
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/config/UpbitClientResourceProperties.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/config/UpbitClientResourceProperties.java
@@ -1,0 +1,18 @@
+package com.dingdongdeng.coinautotrading.exchange.client.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@ConfigurationProperties(prefix = "upbit.client")
+@Configuration
+public class UpbitClientResourceProperties {
+
+    private String accessKey;
+    private String secretKey;
+
+    private String baseUrl;
+    private int readTimeout;
+    private int connectionTimeout;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/config/UpbitWebClientConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/config/UpbitWebClientConfig.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.exchange.client.config;
+
+import com.dingdongdeng.coinautotrading.common.client.config.WebClientConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Configuration
+public class UpbitWebClientConfig extends WebClientConfig {
+
+    private final UpbitClientResourceProperties properties;
+
+    @Bean
+    public WebClient upbitWebClient() {
+        return makeWebClient(properties.getBaseUrl(), properties.getReadTimeout(), properties.getConnectionTimeout());
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitEnum.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitEnum.java
@@ -1,0 +1,88 @@
+package com.dingdongdeng.coinautotrading.exchange.client.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderState;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class UpbitEnum {
+
+    @Getter
+    @AllArgsConstructor
+    public enum State {
+
+        wait("체결 대기", OrderState.WAIT),
+        watch("예약주문 대기", OrderState.WATCH),
+        done("전체 체결 완료", OrderState.DONE),
+        cancel("주문 취소", OrderState.CANCEL);
+
+        private String desc;
+        private OrderState orderState;
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum MarketType {
+        KRW_ETH("원화 이더리움", "KRW-ETH", CoinType.ETHEREUM),
+        ;
+        private String desc;
+        private String code;
+        private CoinType coinType;
+
+        public static MarketType of(CoinType coinType) {
+            return Arrays.stream(MarketType.values())
+                .filter(type -> type.getCoinType() == coinType)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException(coinType.name()));
+        }
+
+        public static MarketType of(String code) {
+            return Arrays.stream(MarketType.values())
+                .filter(type -> type.getCode().equalsIgnoreCase(code))
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException(code));
+
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum OrdType {
+        limit("지정가 주문", PriceType.LIMIT_PRICE),
+        price("시장가 주문(매수)", PriceType.BUYING_MARKET_PRICE),
+        market("시장가 주문(매도)", PriceType.SELLING_MARKET_PRICE),
+        ;
+        private String desc;
+        private PriceType priceType;
+
+        public static OrdType of(PriceType priceType) {
+            return Arrays.stream(OrdType.values())
+                .filter(type -> type.getPriceType() == priceType)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException(priceType.name()));
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum Side {
+        bid("매수", OrderType.BUY),
+        ask("매도", OrderType.SELL),
+        ;
+
+        private String desc;
+        private OrderType orderType;
+
+        public static Side of(OrderType orderType) {
+            return Arrays.stream(Side.values())
+                .filter(type -> type.getOrderType() == orderType)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException(orderType.name()));
+        }
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitRequest.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitRequest.java
@@ -1,0 +1,150 @@
+package com.dingdongdeng.coinautotrading.exchange.client.model;
+
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.OrdType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.Side;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.State;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+public class UpbitRequest {
+
+    @ToString
+    @Getter
+    @Builder
+    public static class OrderChanceRequest {
+
+        @JsonProperty("market")
+        private String market; // 마켓 ID
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderInfoRequest {
+
+        @JsonProperty("uuid")
+        private String uuid; // 주문 UUID
+        @JsonProperty("identifier")
+        private String identifier; // 조회용 사용자 지정 값
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderInfoListRequest {
+
+        @JsonProperty("market")
+        private String market; // 마켓 아이디
+        @JsonProperty("uuids[]")
+        private List<String> uuidList; // 주문 UUID의 목록
+        @JsonProperty("identifiers")
+        private List<String> identifierList; // 주문 identifier의 목록
+        @JsonProperty("state")
+        private State state; // 주문 상태
+        @JsonProperty("states")
+        private List<State> stateList; // 주문 상태의 목록 //* 미체결 주문(wait, watch)과 완료 주문(done, cancel)은 혼합하여 조회하실 수 없습니다.
+        @JsonProperty("page")
+        private Integer page; // 페이지 수, default: 1
+        @JsonProperty("limit")
+        private Integer limit; // 요청 개수, default: 100
+        @JsonProperty("order_by")
+        private String orderBy; // 정렬 방식 - asc : 오름차순 - desc : 내림차순 (default)
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class MarketCodeRequest {
+
+        @JsonProperty("isDetail")
+        private boolean isDetail; // 유의종목 필드과 같은 상세 정보 노출 여부
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderRequest {
+
+        @JsonProperty("market")
+        private String market; // 마켓 ID (필수)
+        @JsonProperty("side")
+        private Side side; // 주문 종류 (필수) - bid : 매수 - ask : 매도
+        @JsonProperty("volume")
+        private Double volume; // 주문량 (지정가, 시장가 매도 시 필수)
+        @JsonProperty("price")
+        private Double price; // 주문 가격. (지정가, 시장가 매수 시 필수)  ex) KRW-BTC 마켓에서 1BTC당 1,000 KRW로 거래할 경우, 값은 1000 이 된다. ex) KRW-BTC 마켓에서 1BTC당 매도 1호가가 500 KRW 인 경우, 시장가 매수 시 값을 1000으로 세팅하면 2BTC가 매수된다. (수수료가 존재하거나 매도 1호가의 수량에 따라 상이할 수 있음)
+        @JsonProperty("ord_type")
+        private OrdType ordType; // 주문 타입 (필수) - limit : 지정가 주문 - price : 시장가 주문(매수) - market : 시장가 주문(매도)
+        @JsonProperty("identifier")
+        private String identifier; // 조회용 사용자 지정값 (선택) (Uniq 값 사용)
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderCancelRequest {
+
+        @JsonProperty("uuid")
+        private String uuid; // 취소할 주문의 UUID
+        @JsonProperty("identifier")
+        private String identifier; // 조회용 사용자 지정값
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class CandleRequest {
+
+        private Integer unit; // 분 단위. 가능한 값 : 1, 3, 5, 15, 10, 30, 60, 240
+        private String market; // 마켓 ID (필수)
+        @JsonIgnore
+        private LocalDateTime toKst;
+        private Integer count; // 캔들 개수(최대 200개)
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime getTo() { // 마지막 캔들 시각 (비우면 가장 최근 시각), UTC 기준
+            if (Objects.isNull(toKst)) {
+                return null;
+            }
+            return toKst.atZone(ZoneId.of("Asia/Seoul"))
+                .withZoneSameInstant(ZoneId.of("UTC"))
+                .toLocalDateTime();
+        }
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderBookRequest {
+
+        @JsonProperty("markets")
+        private List<String> marketList;
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    @JsonInclude(Include.NON_NULL)
+    public static class TickerRequest {
+
+        @JsonProperty("markets")
+        private List<String> marketList;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitResponse.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/client/model/UpbitResponse.java
@@ -1,0 +1,361 @@
+package com.dingdongdeng.coinautotrading.exchange.client.model;
+
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.OrdType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.Side;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.State;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@ToString
+public class UpbitResponse {
+
+    @ToString
+    @Getter
+    public static class AccountsResponse {
+
+        @JsonProperty("currency")
+        private String currency; // 화폐를 의미하는 영문 대문자 코드
+        @JsonProperty("balance")
+        private Double balance; // 주문가능 금액/수량
+        @JsonProperty("locked")
+        private Double locked; // 주문 중 묶여있는 금액/수량
+        @JsonProperty("avg_buy_price")
+        private Double avgBuyPrice; // 매수평균가
+        @JsonProperty("avg_buy_price_modified")
+        private boolean avgBuyPriceModified; // 매수평균가 수정 여부
+        @JsonProperty("unit_currency")
+        private String unitCurrency; // 평단가 기준 화폐
+    }
+
+    @ToString
+    @Getter
+    public static class OrdersChanceResponse {
+
+        @JsonProperty("ask_fee")
+        private String askFee; // 매도 수수료 비율
+        @JsonProperty("market")
+        private MarketResponse market; // 마켓에 대한 정보
+        @JsonProperty("bid_account")
+        private BidAccountResponse bidAccount; // 매수 시 사용하는 화폐의 계좌 상태
+        @JsonProperty("ask_account")
+        private AskAccountResponse askAccount; // 매도 시 사용하는 화폐의 계좌 상태
+    }
+
+    @ToString
+    @Getter
+    public static class MarketResponse {
+
+        @JsonProperty("id")
+        private String id; // 마켓의 유일 키
+        @JsonProperty("name")
+        private String name; // 마켓 이름
+        @JsonProperty("order_types")
+        private List<String> orderTypes; // 지원 주문 방식
+        @JsonProperty("order_sides")
+        private List<String> orderSides; //	지원 주문 종류
+        @JsonProperty("bid")
+        private BidResponse bid; //	매수 시 제약사항
+        @JsonProperty("ask")
+        private AskResponse ask; //	매도 시 제약사항
+        @JsonProperty("max_total")
+        private Double maxTotal; // 최대 매도/매수 금액
+        @JsonProperty("state")
+        private String state; // 마켓 운영 상태
+    }
+
+    @ToString
+    @Getter
+    public static class BidResponse {
+
+        @JsonProperty("currency	")
+        private String currency; // 화폐를 의미하는 영문 대문자 코드
+        @JsonProperty("price_unit")
+        private String priceUnit; // 주문금액 단위
+        @JsonProperty("min_total")
+        private Double minTotal; // 최소 매도/매수 금액
+    }
+
+    @ToString
+    @Getter
+    public static class AskResponse {
+
+        @JsonProperty("currency	")
+        private String currency; // 화폐를 의미하는 영문 대문자 코드
+        @JsonProperty("price_unit")
+        private String priceUnit; // 주문금액 단위
+        @JsonProperty("min_total")
+        private Double minTotal; // 최소 매도/매수 금액
+    }
+
+    @ToString
+    @Getter
+    public static class BidAccountResponse {
+
+        @JsonProperty("currency")
+        private String currency; // 화폐를 의미하는 영문 대문자 코드
+        @JsonProperty("balance")
+        private Double balance; // 주문가능 금액/수량
+        @JsonProperty("locked")
+        private Double locked; // 주문 중 묶여있는 금액/수량
+        @JsonProperty("avg_buy_price")
+        private Double avgBuyPrice; //	매수평균가
+        @JsonProperty("avg_buy_price_modified")
+        private boolean avgBuyPriceModified; //	매수평균가 수정 여부
+        @JsonProperty("unit_currency")
+        private String unitCurrency; //	평단가 기준 화폐
+    }
+
+    @ToString
+    @Getter
+    public static class AskAccountResponse {
+
+        @JsonProperty("currency")
+        private String currency; //	화폐를 의미하는 영문 대문자 코드
+        @JsonProperty("balance")
+        private Double balance; // 주문가능 금액/수량
+        @JsonProperty("locked")
+        private Double locked; // 주문 중 묶여있는 금액/수량
+        @JsonProperty("avg_buy_price")
+        private Double avgBuyPrice; // 매수평균가
+        @JsonProperty("avg_buy_price_modified")
+        private boolean avgBuyPriceModified; // 매수평균가 수정 여부
+        @JsonProperty("unit_currency")
+        private String unitCurrency; // 평단가 기준 화폐
+    }
+
+    @ToString
+    @Getter
+    public static class MarketCodeResponse {
+
+        @JsonProperty("market")
+        private String market; // 업비트에서 제공중인 시장 정보
+        @JsonProperty("korean_name")
+        private String koreanName; // 거래 대상 암호화폐 한글명
+        @JsonProperty("english_name")
+        private String englishName; // 거래 대상 암호화폐 영문명
+        @JsonProperty("market_warning")
+        private String marketWarning; // 유의 종목 여부 NONE (해당 사항 없음), CAUTION(투자유의)
+    }
+
+    @ToString
+    @Getter
+    @JsonInclude(Include.NON_NULL)
+    public static class OrderResponse {
+
+        @JsonProperty("uuid")
+        private String uuid; // 주문의 고유 아이디
+        @JsonProperty("side")
+        private Side side; // 주문 종류
+        @JsonProperty("ord_type")
+        private OrdType ordType; // 주문 방식
+        @JsonProperty("price")
+        private Double price; // 주문 당시 화폐 가격
+        @JsonProperty("avg_price")
+        private Double avgPrice; // 체결 가격의 평균가
+        @JsonProperty("state")
+        private State state; // 주문 상태
+        @JsonProperty("market")
+        private String market; // 마켓의 유일키
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        @JsonProperty("created_at")
+        private LocalDateTime createdAt; // 주문 생성 시간
+        @JsonProperty("volume")
+        private Double volume; // 사용자가 입력한 주문 양
+        @JsonProperty("remaining_volume")
+        private Double remainingVolume; // 체결 후 남은 주문 양
+        @JsonProperty("reserved_fee")
+        private Double reservedFee; // 수수료로 예약된 비용
+        @JsonProperty("remaining_fee")
+        private Double remainingFee; // 남은 수수료
+        @JsonProperty("paid_fee")
+        private Double paidFee; // 사용된 수수료
+        @JsonProperty("locked")
+        private Double locked; // 거래에 사용중인 비용
+        @JsonProperty("executed_volume")
+        private Double executedVolume; // 체결된 양
+        @JsonProperty("trade_count")
+        private Long tradeCount; // 해당 주문에 걸린 체결 수
+        @JsonProperty("trades")
+        private List<TradeResponse> tradeList; // 체결
+    }
+
+    @ToString
+    @Getter
+    public static class TradeResponse {
+
+        @JsonProperty("market")
+        private String market; // 마켓의 유일 키
+        @JsonProperty("uuid")
+        private String uuid; // 체결의 고유 아이디
+        @JsonProperty("price")
+        private Double price; // 체결 가격
+        @JsonProperty("volume")
+        private String volume; // 체결 양
+        @JsonProperty("funds")
+        private String funds; // 체결된 총 가격
+        @JsonProperty("side")
+        private Side side; // 체결 종류
+        @JsonProperty("created_at")
+        private String createdAt; // 체결 시각
+    }
+
+    @ToString
+    @Getter
+    public static class OrderCancelResponse {
+
+        @JsonProperty("uuid")
+        private String uuid; // 주문의 고유 아이디
+        @JsonProperty("side")
+        private Side side; // 주문 종류
+        @JsonProperty("ord_type")
+        private OrdType ordType; // 주문 방식
+        @JsonProperty("price")
+        private Double price; // 주문 당시 화폐 가격
+        @JsonProperty("state")
+        private State state; // 주문 상태
+        @JsonProperty("market")
+        private String market; // 마켓의 유일키
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        @JsonProperty("created_at")
+        private LocalDateTime createdAt; // 주문 생성 시간
+        @JsonProperty("volume")
+        private Double volume; // 사용자가 입력한 주문 양
+        @JsonProperty("remaining_volume")
+        private Double remainingVolume; // 체결 후 남은 주문 양
+        @JsonProperty("reserved_fee")
+        private Double reservedFee; // 수수료로 예약된 비용
+        @JsonProperty("remaining_fee")
+        private Double remainingFee; // 남은 수수료
+        @JsonProperty("paid_fee")
+        private Double paidFee; // 사용된 수수료
+        @JsonProperty("locked")
+        private Double locked; // 거래에 사용중인 비용
+        @JsonProperty("executed_volume")
+        private Double executedVolume; // 체결된 양
+        @JsonProperty("trade_count")
+        private Long tradeCount; // 해당 주문에 걸린 체결 수
+    }
+
+    @ToString
+    @Getter
+    public static class CandleResponse {
+
+        @JsonProperty("market")
+        private String market; // 마켓명
+        @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ss")
+        @JsonProperty("candle_date_time_utc")
+        private LocalDateTime candleDateTimeUtc; // 캔들 기준 시각(UTC 기준)
+        @DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm:ss")
+        @JsonProperty("candle_date_time_kst")
+        private LocalDateTime candleDateTimeKst; // 캔들 기준 시각(KST 기준)
+        @JsonProperty("opening_price")
+        private Double openingPrice; // 시가
+        @JsonProperty("high_price")
+        private Double highPrice; // 고가
+        @JsonProperty("low_price")
+        private Double lowPrice; // 저가
+        @JsonProperty("trade_price")
+        private Double tradePrice; // 종가
+        @JsonProperty("timestamp")
+        private Long timestamp; // 해당 캔들에서 마지막 틱이 저장된 시각
+        @JsonProperty("candle_acc_trade_price")
+        private Double candleAccTradePrice; // 누적 거래 금액
+        @JsonProperty("candle_acc_trade_volume")
+        private Double candleAccTradeVolume; // 누적 거래량
+        @JsonProperty("unit")
+        private Integer unit; // 분 단위(유닛)
+    }
+
+    @ToString
+    @Getter
+    public static class OrderBookResponse {
+
+        @JsonProperty("market")
+        private String market; // 마켓 코드
+        @JsonProperty("timestamp")
+        private Long timestamp; // 호가 생성 시각
+        @JsonProperty("total_ask_size")
+        private Double totalAskSize; // 호가 매도 총 잔량
+        @JsonProperty("total_bid_size")
+        private Double totalBidSize; // 호가 매수 총 잔량
+        @JsonProperty("orderbook_units")
+        private List<OrderBookUnitResponse> orderbookUnitList; // 호가
+    }
+
+    @ToString
+    @Getter
+    public static class OrderBookUnitResponse {
+
+        @JsonProperty("ask_price")
+        private Double askPrice; // 매도호가
+        @JsonProperty("bid_price")
+        private Double bidPrice; // 매수호가
+        @JsonProperty("ask_size")
+        private Double askSize; // 매도 잔량
+        @JsonProperty("bid_size")
+        private Double bidSize; // 매수 잔량
+    }
+
+    @ToString
+    @Getter
+    public static class TickerResponse {
+
+        @JsonProperty("market")
+        private String market;  //종목 구분 코드
+        @JsonProperty("trade_date")
+        private String tradeDate;  //최근 거래 일자(UTC)
+        @JsonProperty("trade_time")
+        private String tradeTime;  //최근 거래 시각(UTC)
+        @JsonProperty("trade_date_kst")
+        private String tradeDateKst;  //최근 거래 일자(KST)
+        @JsonProperty("trade_time_kst")
+        private String tradeTimeKst;  //최근 거래 시각(KST)
+        @JsonProperty("opening_price")
+        private Double openingPrice;  //시가
+        @JsonProperty("high_price")
+        private Double highPrice;  //고가
+        @JsonProperty("low_price")
+        private Double lowPrice;  //저가
+        @JsonProperty("trade_price")
+        private Double tradePrice;  //종가
+        @JsonProperty("prev_closing_price")
+        private Double prevClosingPrice;  //전일 종가
+        @JsonProperty("change")
+        private String change; //EVEN : 보합   RISE : 상승   FALL : 하락
+        @JsonProperty("change_price")
+        private Double changePrice;  //변화액의 절대값
+        @JsonProperty("change_rate")
+        private Double changeRate;  //변화율의 절대값
+        @JsonProperty("signed_change_price")
+        private Double signedChangePrice;  //부호가 있는 변화액
+        @JsonProperty("signed_change_rate")
+        private Double signedChangeRate;  //부호가 있는 변화율
+        @JsonProperty("trade_volume")
+        private Double tradeVolume;  //가장 최근 거래량
+        @JsonProperty("acc_trade_price")
+        private Double accTradePrice;  //누적 거래대금(UTC 0시 기준)
+        @JsonProperty("acc_trade_price_24h")
+        private Double accTradePrice24h;  //24시간 누적 거래대금
+        @JsonProperty("acc_trade_volume")
+        private Double accTradeVolume;  //누적 거래량(UTC 0시 기준)
+        @JsonProperty("acc_trade_volume_24h")
+        private Double accTradeVolume24h;  //24시간 누적 거래량
+        @JsonProperty("highest_52_week_price")
+        private Double highest52WeekPrice;  //52주 신고가
+        @JsonProperty("highest_52_week_date")
+        private String highest52WeekDate;  //52주 신고가 달성일
+        @JsonProperty("lowest_52_week_price")
+        private Double lowest52WeekPrice;  //52주 신저가
+        @JsonProperty("lowest_52_week_date")
+        private String lowest52WeekDate;  //52주 신저가 달성일
+        @JsonProperty("timestamp")
+        private Long timestamp;  //타임스탬프
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/component/IndexCalculator.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/component/IndexCalculator.java
@@ -1,0 +1,45 @@
+package com.dingdongdeng.coinautotrading.exchange.component;
+
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles.Candle;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class IndexCalculator {
+
+    private final int RSI_STANDARD_PERIOD = 14;
+
+    public double getRsi(ExchangeCandles candles, Double currentPrice) {
+        List<Candle> candleList = candles.getCandleList().subList(0, RSI_STANDARD_PERIOD);
+        candleList.add(0, Candle.builder().tradePrice(currentPrice).build());
+
+        double AU = 0d;
+        double AD = 0d;
+        for (int i = 0; i < candleList.size(); i++) {
+            if (!hasNext(i, candleList.size())) {
+                break;
+            }
+            double todayPrice = candleList.get(i).getTradePrice();
+            double yesterdayPrice = candleList.get(i + 1).getTradePrice();
+
+            if (todayPrice > yesterdayPrice) {
+                AU += todayPrice - yesterdayPrice;
+            } else {
+                AD += yesterdayPrice - todayPrice;
+            }
+
+        }
+
+        double RS = AU / AD;
+        return RS / (1 + RS);
+    }
+
+    private boolean hasNext(int index, int size) {
+        return index + 1 < size;
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/CandleStoreJob.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/CandleStoreJob.java
@@ -1,0 +1,64 @@
+package com.dingdongdeng.coinautotrading.exchange.scheduler;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.domain.entity.Candle;
+import com.dingdongdeng.coinautotrading.domain.service.CandleService;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeCandleService;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+@RequiredArgsConstructor
+@Slf4j
+public abstract class CandleStoreJob implements Job {
+
+    private final List<CoinType> TARGET_COINT_LIST;
+    private final CandleUnit CANDLE_UNIT;
+    private final int LIMIT_DAYS = 2;
+    private final ExchangeCandleService exchangeCandleService;
+    private final CandleService candleService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        if (true) {
+            return; //fixme 스케줄러가 아니라 백테스팅 세팅할때 로직 사용하도록하자
+        }
+        log.info("run CandleStorJob");
+        TARGET_COINT_LIST.forEach(coinType -> {
+            Candle candle = candleService.findOneLastCandle(exchangeCandleService.getCoinExchangeType(), coinType, CANDLE_UNIT)
+                .orElse(Candle.builder().candleDateTimeKst(LocalDateTime.now().minusDays(LIMIT_DAYS)).build());
+            ExchangeCandles exchangeCandlesList = exchangeCandleService.getCandleList(coinType, CANDLE_UNIT, candle.getCandleDateTimeKst(), LocalDateTime.now());
+            candleService.saveAll(makeCandleList(exchangeCandlesList));
+        });
+
+        //fixme CompletedFuture를 활용할수 있는 구조로 해보자
+        // 중복 저장의 위험은 unique 컬럼을 설정해서 방지하는게 좋을거같아(거의 발생안할 이슈라고 판단됨)
+    }
+
+    private List<Candle> makeCandleList(ExchangeCandles exchangeCandles) {
+        CoinType coinType = exchangeCandles.getCoinType();
+        CandleUnit candleUnit = exchangeCandles.getCandleUnit();
+        return exchangeCandles.getCandleList().stream()
+            .map(candle -> Candle.builder()
+                .coinType(coinType)
+                .coinExchangeType(exchangeCandles.getCoinExchangeType())
+                .candleUnit(candleUnit)
+                .candleDateTimeUtc(candle.getCandleDateTimeUtc())
+                .candleDateTimeKst(candle.getCandleDateTimeKst())
+                .openingPrice(candle.getOpeningPrice())
+                .highPrice(candle.getHighPrice())
+                .lowPrice(candle.getLowPrice())
+                .tradePrice(candle.getTradePrice())
+                .candleAccTradePrice(candle.getCandleAccTradePrice())
+                .candleAccTradeVolume(candle.getCandleAccTradeVolume())
+                .build())
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/UpbitCandleStoreJob.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/UpbitCandleStoreJob.java
@@ -1,0 +1,18 @@
+package com.dingdongdeng.coinautotrading.exchange.scheduler;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.domain.service.CandleService;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeCandleService;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UpbitCandleStoreJob extends CandleStoreJob {
+
+    public UpbitCandleStoreJob(ExchangeCandleService upbitExchangeCandleService, CandleService candleService) {
+        super(List.of(CoinType.ETHEREUM), CandleUnit.UNIT_1M, upbitExchangeCandleService, candleService);
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/config/QuartzConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/scheduler/config/QuartzConfig.java
@@ -1,0 +1,38 @@
+package com.dingdongdeng.coinautotrading.exchange.scheduler.config;
+
+import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
+
+import com.dingdongdeng.coinautotrading.exchange.scheduler.UpbitCandleStoreJob;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("!test")
+@Configuration
+public class QuartzConfig {
+
+    public static class UpbitQuartzConfig {
+
+        @Bean
+        public JobDetail upbitCandleStoreJobDetail() {
+            return JobBuilder.newJob().ofType(UpbitCandleStoreJob.class)
+                .storeDurably()
+                .withIdentity("Qrtz_Job_Detail")
+                .withDescription("Invoke Sample Job service...")
+                .build();
+        }
+
+        @Bean
+        public Trigger upbitCandleStoreTrigger(JobDetail upbitCandleStoreJobDetail) {
+            return TriggerBuilder.newTrigger().forJob(upbitCandleStoreJobDetail)
+                .withIdentity("Qrtz_Trigger")
+                .withDescription("Sample trigger")
+                .withSchedule(simpleSchedule().repeatForever().withIntervalInSeconds(5))
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeCandleService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeCandleService.java
@@ -1,0 +1,14 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import java.time.LocalDateTime;
+
+public interface ExchangeCandleService {
+
+    ExchangeCandles getCandleList(CoinType coinType, CandleUnit candleUnit, LocalDateTime start, LocalDateTime end);
+
+    CoinExchangeType getCoinExchangeType();
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeService.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrder;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancel;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancelParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfo;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfoParam;
+
+public interface ExchangeService {
+
+    ExchangeOrder order(ExchangeOrderParam param);
+
+    ExchangeOrderCancel orderCancel(ExchangeOrderCancelParam param);
+
+    ExchangeTradingInfo getTradingInformation(ExchangeTradingInfoParam param);
+
+    CoinExchangeType getExchangeType();
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeServiceSelector.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/ExchangeServiceSelector.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ExchangeServiceSelector {
+
+    private final List<ExchangeService> processorList;
+
+    public ExchangeService getTargetProcessor(CoinExchangeType coinExchangeType) {
+        return processorList.stream()
+            .filter(processor -> processor.getExchangeType() == coinExchangeType)
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeCandleService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeCandleService.java
@@ -1,0 +1,112 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.exchange.client.UpbitClient;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.MarketType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.CandleRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.CandleResponse;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class UpbitExchangeCandleService implements ExchangeCandleService {
+
+    private final CoinExchangeType COIN_EXCHANGE_TYPE = CoinExchangeType.UPBIT;
+    private final UpbitClient upbitClient;
+    private final long MAX_COUNT_SIZE = 200;
+
+    @Override
+    public ExchangeCandles getCandleList(CoinType coinType, CandleUnit candleUnit, LocalDateTime start, LocalDateTime end) {
+        LocalDateTime limitedEndDateTime = getlimitedEndDateTime(candleUnit, start, end);
+        int candleCount = getCandleCount(candleUnit, start, limitedEndDateTime);
+
+        List<CandleResponse> response = upbitClient.getMinuteCandle(
+            CandleRequest.builder()
+                .unit(candleUnit.getSize())
+                .market(MarketType.of(coinType).getCode())
+                .toKst(limitedEndDateTime)
+                .count(candleCount)
+                .build()
+        );
+        return ExchangeCandles.builder()
+            .coinExchangeType(COIN_EXCHANGE_TYPE)
+            .candleUnit(candleUnit)
+            .coinType(coinType)
+            .candleList(
+                response.stream().map(
+                    candle -> ExchangeCandles.Candle.builder()
+                        .candleDateTimeUtc(candle.getCandleDateTimeUtc())
+                        .candleDateTimeKst(candle.getCandleDateTimeKst())
+                        .openingPrice(candle.getOpeningPrice())
+                        .highPrice(candle.getHighPrice())
+                        .lowPrice(candle.getLowPrice())
+                        .tradePrice(candle.getTradePrice())
+                        .timestamp(candle.getTimestamp())
+                        .candleAccTradePrice(candle.getCandleAccTradePrice())
+                        .candleAccTradeVolume(candle.getCandleAccTradeVolume())
+                        .build()
+                ).collect(Collectors.toList())
+            )
+            .build();
+    }
+
+    @Override
+    public CoinExchangeType getCoinExchangeType() {
+        return COIN_EXCHANGE_TYPE;
+    }
+
+    private LocalDateTime getlimitedEndDateTime(CandleUnit candleUnit, LocalDateTime start, LocalDateTime end) {
+        LocalDateTime limitedEndDateTime;
+        switch (candleUnit.getUnitType()) {
+            case WEEK:
+                limitedEndDateTime = start.plusWeeks(MAX_COUNT_SIZE);
+                break;
+            case DAY:
+                limitedEndDateTime = start.plusDays(MAX_COUNT_SIZE);
+                break;
+            case MIN:
+                limitedEndDateTime = start.plusMinutes(MAX_COUNT_SIZE);
+                break;
+            default:
+                throw new NoSuchElementException("fail make limitedEndDateTime");
+        }
+        return end.isAfter(limitedEndDateTime) ? limitedEndDateTime : end;
+    }
+
+
+    private int getCandleCount(CandleUnit candleUnit, LocalDateTime start, LocalDateTime limitedEndDateTime) {
+        Long diff = null;
+        switch (candleUnit.getUnitType()) {
+            case WEEK:
+                diff = ChronoUnit.WEEKS.between(start, limitedEndDateTime);
+                break;
+            case DAY:
+                diff = ChronoUnit.DAYS.between(start, limitedEndDateTime);
+                break;
+            case MIN:
+                diff = ChronoUnit.MINUTES.between(start, limitedEndDateTime);
+                if (limitedEndDateTime.getSecond() == 0) {
+                    diff = diff - 1;
+                }
+                break;
+            default:
+                throw new NoSuchElementException("fail make candleCount");
+        }
+
+        if (diff > 200) {
+            throw new RuntimeException("upbit candle max size over");
+        }
+        return diff.intValue();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeService.java
@@ -1,0 +1,224 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.exchange.client.UpbitClient;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.MarketType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.OrdType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.Side;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.State;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.CandleRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderCancelRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderInfoListRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.TickerRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.AccountsResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.CandleResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderCancelResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.TickerResponse;
+import com.dingdongdeng.coinautotrading.exchange.component.IndexCalculator;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrder;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancel;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancelParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTicker;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfo;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfoParam;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UpbitExchangeService implements ExchangeService {
+
+    private final UpbitClient upbitClient;
+    private final IndexCalculator indexCalculator;
+
+    @Override
+    public ExchangeOrder order(ExchangeOrderParam param) {
+        log.info("upbit process : order param = {}", param);
+        OrderResponse response = upbitClient.order(
+            OrderRequest.builder()
+                .market(MarketType.of(param.getCoinType()).getCode())
+                .side(Side.of(param.getOrderType()))
+                .volume(param.getVolume())
+                .price(param.getPrice())
+                .ordType(OrdType.of(param.getPriceType()))
+                .build()
+        );
+        return makeExchangeOrder(response);
+    }
+
+    @Override
+    public ExchangeOrderCancel orderCancel(ExchangeOrderCancelParam param) {
+        log.info("upbit process : order cancel param = {}", param);
+        OrderCancelResponse response = upbitClient.orderCancel(
+            OrderCancelRequest.builder()
+                .uuid(param.getOrderId())
+                .build()
+        );
+        return ExchangeOrderCancel.builder()
+            .orderId(response.getUuid())
+            .orderType(response.getSide().getOrderType())
+            .priceType(response.getOrdType().getPriceType())
+            .price(response.getPrice())
+            .orderState(response.getState().getOrderState())
+            .coinType(MarketType.of(response.getMarket()).getCoinType())
+            .createdAt(response.getCreatedAt())
+            .volume(response.getVolume())
+            .remainingVolume(response.getRemainingVolume())
+            .reservedFee(response.getReservedFee())
+            .remainingFee(response.getRemainingFee())
+            .paidFee(response.getPaidFee())
+            .locked(response.getLocked())
+            .executedVolume(response.getExecutedVolume())
+            .tradeCount(response.getTradeCount())
+            .build();
+    }
+
+    @Override
+    public ExchangeTradingInfo getTradingInformation(ExchangeTradingInfoParam param) {
+        log.info("upbit process : get trading information param = {}", param);
+
+        // 미체결 주문내역 조회
+        List<ExchangeOrder> undecidedExchangeOrderList = getUndecidedOrderList(param);
+
+        // 캔들 정보 조회
+        ExchangeCandles candles = getExchangeCandles(param);
+
+        // 현재가 정보 조회
+        ExchangeTicker ticker = getExchangeTicker(param);
+
+        // 계좌 정보 조회
+        AccountsResponse accounts = upbitClient.getAccounts().stream().findFirst().orElseThrow(() -> new NoSuchElementException("계좌를 찾지 못함"));
+
+        return ExchangeTradingInfo.builder()
+            .currency(accounts.getCurrency())
+            .balance(accounts.getBalance())
+            .locked(accounts.getLocked())
+
+            .avgBuyPrice(accounts.getAvgBuyPrice())
+            .avgBuyPriceModified(accounts.isAvgBuyPriceModified())
+            .unitCurrency(accounts.getUnitCurrency())
+
+            .undecidedExchangeOrderList(undecidedExchangeOrderList)
+            .candles(candles)
+            .ticker(ticker)
+
+            .rsi(indexCalculator.getRsi(candles, ticker.getTradePrice()))
+            .build();
+    }
+
+    @Override
+    public CoinExchangeType getExchangeType() {
+        return CoinExchangeType.UPBIT;
+    }
+
+    private List<ExchangeOrder> getUndecidedOrderList(ExchangeTradingInfoParam param) {
+        return upbitClient.getOrderInfoList(
+            OrderInfoListRequest.builder()
+                .market(MarketType.of(param.getCoinType()).getCode())
+                .stateList(List.of(State.wait, State.watch))
+                .build())
+            .stream()
+            .map(this::makeExchangeOrder)
+            .collect(Collectors.toList());
+    }
+
+    private ExchangeCandles getExchangeCandles(ExchangeTradingInfoParam param) {
+        TradingTerm tradingTerm = param.getTradingTerm();
+        List<CandleResponse> response = upbitClient.getMinuteCandle(
+            CandleRequest.builder()
+                .unit(tradingTerm.getCandleUnit().getSize())
+                .market(MarketType.of(param.getCoinType()).getCode())
+                .toKst(LocalDateTime.now())
+                .count(200)
+                .build()
+        );
+        return ExchangeCandles.builder()
+            .coinExchangeType(getExchangeType())
+            .candleUnit(tradingTerm.getCandleUnit())
+            .coinType(param.getCoinType())
+            .candleList(
+                response.stream().map(
+                    candle -> ExchangeCandles.Candle.builder()
+                        .candleDateTimeUtc(candle.getCandleDateTimeUtc())
+                        .candleDateTimeKst(candle.getCandleDateTimeKst())
+                        .openingPrice(candle.getOpeningPrice())
+                        .highPrice(candle.getHighPrice())
+                        .lowPrice(candle.getLowPrice())
+                        .tradePrice(candle.getTradePrice())
+                        .timestamp(candle.getTimestamp())
+                        .candleAccTradePrice(candle.getCandleAccTradePrice())
+                        .candleAccTradeVolume(candle.getCandleAccTradeVolume())
+                        .build()
+                ).collect(Collectors.toList())
+            )
+            .build();
+    }
+
+    private ExchangeOrder makeExchangeOrder(OrderResponse response) {
+        return ExchangeOrder.builder()
+            .orderId(response.getUuid())
+            .orderType(response.getSide().getOrderType())
+            .priceType(response.getOrdType().getPriceType())
+            .price(response.getPrice())
+            .avgPrice(response.getAvgPrice())
+            .orderState(response.getState().getOrderState())
+            .coinType(MarketType.of(response.getMarket()).getCoinType())
+            .createdAt(response.getCreatedAt())
+            .volume(response.getVolume())
+            .remainingVolume(response.getRemainingVolume())
+            .reservedFee(response.getReservedFee())
+            .remainingFee(response.getRemainingFee())
+            .paidFee(response.getPaidFee())
+            .locked(response.getLocked())
+            .executedVolume(response.getExecutedVolume())
+            .tradeCount(response.getTradeCount())
+            .tradeList(response.getTradeList())
+            .build();
+    }
+
+    private ExchangeTicker getExchangeTicker(ExchangeTradingInfoParam param) {
+        TickerResponse response = upbitClient.getTicker(
+            TickerRequest.builder()
+                .marketList(List.of(MarketType.of(param.getCoinType()).getCode()))
+                .build()
+        ).stream().findFirst().orElseThrow(NoSuchElementException::new);
+        return ExchangeTicker.builder()
+            .market(response.getMarket())
+            .tradeDate(response.getTradeDate())
+            .tradeTime(response.getTradeTime())
+            .tradeDateKst(response.getTradeDateKst())
+            .tradeTimeKst(response.getTradeTimeKst())
+            .openingPrice(response.getOpeningPrice())
+            .highPrice(response.getHighPrice())
+            .lowPrice(response.getLowPrice())
+            .tradePrice(response.getTradePrice())
+            .prevClosingPrice(response.getPrevClosingPrice())
+            .change(response.getChange())
+            .changePrice(response.getChangePrice())
+            .changeRate(response.getChangeRate())
+            .signedChangePrice(response.getSignedChangePrice())
+            .signedChangeRate(response.getSignedChangeRate())
+            .tradeVolume(response.getTradeVolume())
+            .accTradePrice(response.getAccTradePrice())
+            .accTradePrice24h(response.getAccTradePrice24h())
+            .accTradeVolume(response.getAccTradeVolume())
+            .accTradeVolume24h(response.getAccTradeVolume24h())
+            .highest52WeekPrice(response.getHighest52WeekPrice())
+            .highest52WeekDate(response.getHighest52WeekDate())
+            .lowest52WeekPrice(response.getLowest52WeekPrice())
+            .lowest52WeekDate(response.getLowest52WeekDate())
+            .timestamp(response.getTimestamp())
+            .build();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeCandleParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeCandleParam.java
@@ -1,0 +1,18 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeCandleParam {
+
+    private Integer unit; // 분 단위. 가능한 값 : 1, 3, 5, 15, 10, 30, 60, 240
+    private CoinType coinType; // 마켓 ID (필수)
+    private LocalDateTime to; // 마지막 캔들 시각
+    private Integer count; // 캔들 개수
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeCandles.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeCandles.java
@@ -1,0 +1,38 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeCandles {
+
+    private CoinExchangeType coinExchangeType;
+    private CoinType coinType;
+    private CandleUnit candleUnit; // 분 단위(유닛)
+    private List<Candle> candleList;
+
+
+    @ToString
+    @Getter
+    @Builder
+    public static class Candle {
+
+        private LocalDateTime candleDateTimeUtc; // 캔들 기준 시각(UTC 기준)
+        private LocalDateTime candleDateTimeKst; // 캔들 기준 시각(KST 기준)
+        private Double openingPrice; // 시가
+        private Double highPrice; // 고가
+        private Double lowPrice; // 저가
+        private Double tradePrice; // 종가
+        private Long timestamp; // 해당 캔들에서 마지막 틱이 저장된 시각
+        private Double candleAccTradePrice; // 누적 거래 금액
+        private Double candleAccTradeVolume; // 누적 거래량
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrder.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrder.java
@@ -1,0 +1,36 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderState;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.TradeResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeOrder {
+
+    private String orderId; // 주문의 고유 아이디
+    private OrderType orderType; // 주문 종류
+    private PriceType priceType; // 주문 방식
+    private Double price; // 주문 당시 화폐 가격
+    private Double avgPrice; // 체결 가격의 평균가
+    private OrderState orderState; // 주문 상태
+    private CoinType coinType;
+    private LocalDateTime createdAt; // 주문 생성 시간
+    private Double volume; // 사용자가 입력한 주문 양
+    private Double remainingVolume; // 체결 후 남은 주문 양
+    private Double reservedFee; // 수수료로 예약된 비용
+    private Double remainingFee; // 남은 수수료
+    private Double paidFee; // 사용된 수수료
+    private Double locked; // 거래에 사용중인 비용
+    private Double executedVolume; // 체결된 양
+    private Long tradeCount; // 해당 주문에 걸린 체결 수
+    private List<TradeResponse> tradeList; // 체결
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderCancel.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderCancel.java
@@ -1,0 +1,32 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderState;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeOrderCancel {
+
+    private String orderId; // 주문의 고유 아이디
+    private OrderType orderType; // 주문 종류
+    private PriceType priceType; // 주문 방식
+    private Double price; // 주문 당시 화폐 가격
+    private OrderState orderState; // 주문 상태
+    private CoinType coinType;
+    private LocalDateTime createdAt; // 주문 생성 시간
+    private Double volume; // 사용자가 입력한 주문 양
+    private Double remainingVolume; // 체결 후 남은 주문 양
+    private Double reservedFee; // 수수료로 예약된 비용
+    private Double remainingFee; // 남은 수수료
+    private Double paidFee; // 사용된 수수료
+    private Double locked; // 거래에 사용중인 비용
+    private Double executedVolume; // 체결된 양
+    private Long tradeCount; // 해당 주문에 걸린 체결 수
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderCancelParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderCancelParam.java
@@ -1,0 +1,13 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeOrderCancelParam {
+
+    private String orderId;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeOrderParam.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeOrderParam {
+
+    private CoinType coinType; // 마켓 ID (필수)
+    private OrderType orderType; // 주문 종류 (필수) - bid : 매수 - ask : 매도
+    private Double volume; // 주문량 (지정가, 시장가 매도 시 필수)
+    private Double price; // 주문 가격. (지정가, 시장가 매수 시 필수)  ex) KRW-BTC 마켓에서 1BTC당 1,000 KRW로 거래할 경우, 값은 1000 이 된다. ex) KRW-BTC 마켓에서 1BTC당 매도 1호가가 500 KRW 인 경우, 시장가 매수 시 값을 1000으로 세팅하면 2BTC가 매수된다. (수수료가 존재하거나 매도 1호가의 수량에 따라 상이할 수 있음)
+    private PriceType priceType; // 주문 타입 (필수) - limit : 지정가 주문 - price : 시장가 주문(매수) - market : 시장가 주문(매도)
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTicker.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTicker.java
@@ -1,0 +1,38 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeTicker {
+
+    private String market;  //종목 구분 코드
+    private String tradeDate;  //최근 거래 일자(UTC)
+    private String tradeTime;  //최근 거래 시각(UTC)
+    private String tradeDateKst;  //최근 거래 일자(KST)
+    private String tradeTimeKst;  //최근 거래 시각(KST)
+    private Double openingPrice;  //시가
+    private Double highPrice;  //고가
+    private Double lowPrice;  //저가
+    private Double tradePrice;  //종가
+    private Double prevClosingPrice;  //전일 종가
+    private String change; //EVEN : 보합   RISE : 상승   FALL : 하락
+    private Double changePrice;  //변화액의 절대값
+    private Double changeRate;  //변화율의 절대값
+    private Double signedChangePrice;  //부호가 있는 변화액
+    private Double signedChangeRate;  //부호가 있는 변화율
+    private Double tradeVolume;  //가장 최근 거래량
+    private Double accTradePrice;  //누적 거래대금(UTC 0시 기준)
+    private Double accTradePrice24h;  //24시간 누적 거래대금
+    private Double accTradeVolume;  //누적 거래량(UTC 0시 기준)
+    private Double accTradeVolume24h;  //24시간 누적 거래량
+    private Double highest52WeekPrice;  //52주 신고가
+    private String highest52WeekDate;  //52주 신고가 달성일
+    private Double lowest52WeekPrice;  //52주 신저가
+    private String lowest52WeekDate;  //52주 신저가 달성일
+    private Long timestamp;  //타임스탬프
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTradingInfo.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTradingInfo.java
@@ -1,0 +1,44 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeTradingInfo {
+
+    private CoinExchangeType coinExchangeType;
+    private CoinType coinType;
+    /**
+     * 계좌
+     **/
+    private String currency; // 화폐를 의미하는 영문 대문자 코드
+    private Double balance; // 주문가능 금액/수량
+    private Double locked; // 주문 중 묶여있는 금액/수량
+
+    /**
+     * 주문 정보
+     **/
+    private Double avgBuyPrice; // 매수평균가
+    private boolean avgBuyPriceModified; // 매수평균가 수정 여부
+    private String unitCurrency; // 평단가 기준 화폐
+
+    @Default
+    private List<ExchangeOrder> undecidedExchangeOrderList = new ArrayList<>(); // 미체결 주문 내역
+    private ExchangeCandles candles; // 캔들 정보
+    private ExchangeTicker ticker; // 현재가 정보
+
+    /**
+     * 보조 지표
+     **/
+    private Double rsi;
+
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTradingInfoParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/exchange/service/model/ExchangeTradingInfoParam.java
@@ -1,0 +1,16 @@
+package com.dingdongdeng.coinautotrading.exchange.service.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class ExchangeTradingInfoParam {
+
+    private CoinType coinType;
+    private TradingTerm tradingTerm;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/model/AutoTradingStartParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/model/AutoTradingStartParam.java
@@ -1,0 +1,20 @@
+package com.dingdongdeng.coinautotrading.trading.autotrading.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.StrategyCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class AutoTradingStartParam {
+
+    private CoinType coinType;
+    private CoinExchangeType coinExchangeType;
+    private TradingTerm tradingTerm;
+    private StrategyCode strategyCode;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/model/type/AutoTradingStatus.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/model/type/AutoTradingStatus.java
@@ -1,0 +1,8 @@
+package com.dingdongdeng.coinautotrading.trading.autotrading.model.type;
+
+public enum AutoTradingStatus {
+    INIT,
+    RUNNING,
+    STOPPED,
+    ;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/service/AutoTradingService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/service/AutoTradingService.java
@@ -1,0 +1,65 @@
+package com.dingdongdeng.coinautotrading.trading.autotrading.service;
+
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeService;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeServiceSelector;
+import com.dingdongdeng.coinautotrading.trading.autotrading.model.AutoTradingStartParam;
+import com.dingdongdeng.coinautotrading.trading.autotrading.model.type.AutoTradingStatus;
+import com.dingdongdeng.coinautotrading.trading.strategy.Strategy;
+import com.dingdongdeng.coinautotrading.trading.strategy.StrategyFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AutoTradingService {
+
+    private AutoTradingStatus status = AutoTradingStatus.INIT;
+    private final ExchangeServiceSelector processorSelector;
+    private final StrategyFactory strategyFactory;
+
+    @Async
+    public void start(AutoTradingStartParam param) {
+        if (isRunning()) {
+            return;
+        }
+
+        updateStatus(AutoTradingStatus.RUNNING);
+        ExchangeService exchangeService = processorSelector.getTargetProcessor(param.getCoinExchangeType());
+        Strategy strategy = strategyFactory.create(param.getStrategyCode(), exchangeService, param.getCoinType(), param.getTradingTerm());
+
+        while (isRunning()) {
+            log.info("\n------------------------------ beginning of autotrading cycle -----------------------------------------");
+            delay(1000);
+            try {
+                strategy.execute();
+            } catch (Exception e) {
+                log.error("strategy execute exception : {}", e.getMessage(), e); //fixme 슬랙(이메일은 에러 많이났을때 난사해서 문제될수도)
+            }
+            log.info("\n------------------------------ end of autotrading cycle -----------------------------------------");
+        }
+    }
+
+    public void stop() {
+        updateStatus(AutoTradingStatus.STOPPED);
+    }
+
+    private void updateStatus(AutoTradingStatus status) {
+        this.status = status;
+    }
+
+    private boolean isRunning() {
+        return this.status == AutoTradingStatus.RUNNING;
+    }
+
+    private void delay(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/RsiTradingStrategy.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/RsiTradingStrategy.java
@@ -1,0 +1,157 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeService;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrder;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfo;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingResult;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingTask;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.TradingTag;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RsiTradingStrategy extends Strategy {
+
+    private final double STANDARD_OF_LOW_RSI = 0.25;
+    private final double STANDARD_OF_PROFIT_RATE = 1.3;
+    private final double STANDARD_OF_LOSS_RATE = 0.7;
+    private final double ORDER_PRICE = 5000;
+    private final double ACCOUNT_BALANCE_LIMIT = 3000000; //계좌 금액 안전 장치
+
+    private final StrategyAssistant assistant;
+
+    public RsiTradingStrategy(CoinType coinType, TradingTerm tradingTerm, ExchangeService processor, StrategyAssistant assistant) {
+        super(coinType, tradingTerm, processor);
+        this.assistant = assistant;
+    }
+
+    @Override
+    protected List<TradingTask> makeTradingTask(ExchangeTradingInfo tradingInfo) {
+
+        log.info("tradingInfo : {}", tradingInfo);
+        CoinType coinType = tradingInfo.getCoinType();
+        double rsi = tradingInfo.getRsi();
+        List<ExchangeOrder> undecidedOrderList = tradingInfo.getUndecidedExchangeOrderList();
+
+        /**
+         * 계좌 상태가 거래 가능한지 확인
+         */
+        if (!assistant.isEnoughBalance(tradingInfo.getBalance(), ACCOUNT_BALANCE_LIMIT)) {
+            log.warn("계좌가 거래 가능한 상태가 아님");
+            return List.of(new TradingTask());
+        }
+
+        /**
+         * 미체결 상태가 너무 오래되면, 주문을 취소
+         */
+        List<ExchangeOrder> oldUndecidedBuyOrderList = undecidedOrderList.stream()
+            .filter(o -> ChronoUnit.MINUTES.between(o.getCreatedAt(), LocalDateTime.now()) > 2)
+            .collect(Collectors.toList());
+        if (!oldUndecidedBuyOrderList.isEmpty()) {
+            log.info("미체결 상태의 오래된 주문을 취소");
+            return oldUndecidedBuyOrderList.stream()
+                .map(o -> TradingTask.builder().orderId(o.getOrderId()).build())
+                .collect(Collectors.toList());
+        }
+
+        /**
+         * 매수 주문이 체결된 후 현재 가격을 모니터링하다가 익절/손절 주문을 요청함
+         */
+        TradingResult buyTradingResult = assistant.findBuyTradingResult(this.getClass());
+        TradingResult profitTradingResult = assistant.findProfitTradingResult(this.getClass());
+        TradingResult lossTradingResult = assistant.findLossTradingResult(this.getClass());
+        if (Objects.nonNull(buyTradingResult.getId()) && undecidedOrderList.stream().noneMatch(o -> o.getOrderId().equals(buyTradingResult.getOrderId()))) {
+            log.info("매수 주문이 체결된 상태임");
+            double currentPrice = tradingInfo.getTicker().getTradePrice();
+
+            // 익절/손절 중복 요청 방지
+            if (Objects.nonNull(profitTradingResult.getId()) || Objects.nonNull(lossTradingResult.getId())) {
+                log.info("익절, 손절 주문을 했었음");
+
+                // 익절/손절 체결된 경우 정보 초기화
+                if (undecidedOrderList.isEmpty()) {
+                    log.info("익절, 손절 주문이 체결되었음");
+                    //매수, 익절, 손절에 대한 정보를 모두 초기화
+                    assistant.delete(profitTradingResult);
+                    assistant.delete(lossTradingResult);
+                    assistant.delete(assistant.findBuyTradingResult(this.getClass()));
+                }
+                return List.of(new TradingTask());
+            }
+
+            //익절 주문
+            if (currentPrice > buyTradingResult.getPrice() * STANDARD_OF_PROFIT_RATE) {
+                log.info("익절 주문 요청");
+                return List.of(
+                    TradingTask.builder()
+                        .coinType(coinType)
+                        .orderType(OrderType.SELL)
+                        .volume(buyTradingResult.getVolume())
+                        .price(buyTradingResult.getPrice() * STANDARD_OF_PROFIT_RATE)
+                        .priceType(PriceType.LIMIT_PRICE)
+                        .tag(TradingTag.PROFIT)
+                        .build()
+                );
+            }
+
+            //손절 주문
+            if (currentPrice < buyTradingResult.getPrice() * STANDARD_OF_LOSS_RATE) {
+                log.info("손절 주문 요청");
+                return List.of(
+                    TradingTask.builder()
+                        .coinType(coinType)
+                        .orderType(OrderType.SELL)
+                        .volume(buyTradingResult.getVolume())
+                        .price(buyTradingResult.getPrice() * STANDARD_OF_LOSS_RATE)
+                        .priceType(PriceType.LIMIT_PRICE)
+                        .tag(TradingTag.LOSS)
+                        .build()
+
+                );
+            }
+
+            return List.of(new TradingTask());
+        }
+
+        /**
+         * rsi가 조건을 만족하고, 미체결중인 내역이 없다면 매수 주문을 요청함
+         */
+        if (isBuyTiming(rsi, undecidedOrderList)) {
+            log.info("매수 주문 요청");
+            double price = ORDER_PRICE;
+            double volume = price / tradingInfo.getTicker().getTradePrice();
+
+            return List.of(
+                TradingTask.builder()
+                    .coinType(coinType)
+                    .orderType(OrderType.BUY)
+                    .volume(volume)
+                    .price(price)
+                    .priceType(PriceType.LIMIT_PRICE)
+                    .tag(TradingTag.BUY)
+                    .build()
+            );
+        }
+
+        log.info("아무것도 하지 않음");
+        return List.of(new TradingTask());
+    }
+
+    @Override
+    protected void handleOrderResult(ExchangeOrder order, TradingResult tradingResult) {
+        assistant.saveTradingResult(tradingResult);
+    }
+
+    private boolean isBuyTiming(double rsi, List<ExchangeOrder> undecidedOrderList) {
+        return undecidedOrderList.isEmpty() && rsi < STANDARD_OF_LOW_RSI;
+    }
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/Strategy.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/Strategy.java
@@ -1,0 +1,99 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeService;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrder;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancelParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfo;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfoParam;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingResult;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingTask;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class Strategy {
+
+    private final CoinType coinType;
+    private final TradingTerm tradingTerm;
+    private final ExchangeService exchangeService;
+
+    public void execute() {
+
+        ExchangeTradingInfo exchangeTradingInfo = exchangeService.getTradingInformation(makeExchangeTradingInfoParam(coinType, tradingTerm));
+
+        List<TradingTask> tradingTaskList = this.makeTradingTask(exchangeTradingInfo);
+        log.info("tradingTaskList : {}", tradingTaskList);
+
+        tradingTaskList.forEach(tradingTask -> {
+            // 매수, 매도 주문
+            if (isOrder(tradingTask)) {
+                ExchangeOrder order = exchangeService.order(makeExchangeOrderParam(tradingTask));
+                handleOrderResult(order, makeTradingResult(tradingTask, order));
+                return;
+            }
+
+            // 주문 취소
+            if (isOrderCancel(tradingTask)) {
+                exchangeService.orderCancel(makeExchangeOrderCancelParam(tradingTask));
+            }
+
+            // 아무것도 하지 않음
+        });
+    }
+
+    abstract protected List<TradingTask> makeTradingTask(ExchangeTradingInfo tradingInfo);
+
+    abstract protected void handleOrderResult(ExchangeOrder order, TradingResult tradingResult);
+
+    private boolean isOrder(TradingTask tradingTask) {
+        OrderType orderType = tradingTask.getOrderType();
+        return orderType == OrderType.BUY || orderType == OrderType.SELL;
+    }
+
+    private boolean isOrderCancel(TradingTask tradingTask) {
+        OrderType orderType = tradingTask.getOrderType();
+        return orderType == OrderType.CANCEL;
+    }
+
+    private ExchangeTradingInfoParam makeExchangeTradingInfoParam(CoinType coinType, TradingTerm tradingTerm) {
+        return ExchangeTradingInfoParam.builder()
+            .coinType(coinType)
+            .tradingTerm(tradingTerm)
+            .build();
+    }
+
+    private ExchangeOrderParam makeExchangeOrderParam(TradingTask tradingTask) {
+        return ExchangeOrderParam.builder()
+            .coinType(tradingTask.getCoinType())
+            .orderType(tradingTask.getOrderType())
+            .volume(tradingTask.getVolume())
+            .price(tradingTask.getPrice())
+            .priceType(tradingTask.getPriceType())
+            .build();
+    }
+
+    private ExchangeOrderCancelParam makeExchangeOrderCancelParam(TradingTask tradingTask) {
+        return ExchangeOrderCancelParam.builder()
+            .orderId(tradingTask.getOrderId())
+            .build();
+    }
+
+    private TradingResult makeTradingResult(TradingTask tradingTask, ExchangeOrder exchangeOrder) {
+        return TradingResult.builder()
+            .strategyName(tradingTask.getStrategyName())
+            .coinType(tradingTask.getCoinType())
+            .orderType(tradingTask.getOrderType())
+            .volume(tradingTask.getVolume())
+            .price(tradingTask.getPrice())
+            .priceType(tradingTask.getPriceType())
+            .orderId(exchangeOrder.getOrderId())
+            .tag(tradingTask.getTag())
+            .build();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyAssistant.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyAssistant.java
@@ -1,0 +1,51 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingResult;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.TradingTag;
+import com.dingdongdeng.coinautotrading.trading.strategy.repository.TradingResultRepository;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class StrategyAssistant {
+
+    private final TradingResultRepository tradingResultRepository;
+
+    public void delete(TradingResult tradingResult) {
+        if (Objects.isNull(tradingResult.getId())) {
+            return;
+        }
+        tradingResultRepository.delete(tradingResult);
+    }
+
+    public void saveTradingResult(TradingResult tradingResult) {
+        tradingResult.setId(getKey(tradingResult.getStrategyName(), tradingResult.getTag()));
+        tradingResultRepository.save(tradingResult);
+    }
+
+    public TradingResult findTradingResult(String strategyName, TradingTag tag) {
+        return tradingResultRepository.findById(getKey(strategyName, tag)).orElse(new TradingResult());
+    }
+
+    public TradingResult findProfitTradingResult(Class clazz) {
+        return findTradingResult(clazz.getSimpleName(), TradingTag.PROFIT);
+    }
+
+    public TradingResult findLossTradingResult(Class clazz) {
+        return findTradingResult(clazz.getSimpleName(), TradingTag.LOSS);
+    }
+
+    public TradingResult findBuyTradingResult(Class clazz) {
+        return findTradingResult(clazz.getSimpleName(), TradingTag.BUY);
+    }
+
+    public boolean isEnoughBalance(double balance, double accountBalanceLimit) {
+        return balance > accountBalanceLimit;
+    }
+
+    private String getKey(String strategyName, TradingTag tag) {
+        return strategyName + ":" + tag.name(); // RsiTradingStrategy:BUY
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyFactory.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyFactory.java
@@ -1,0 +1,24 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.exchange.service.ExchangeService;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.StrategyCode;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class StrategyFactory {
+
+    private final StrategyAssistant strategyAssistant;
+
+    public Strategy create(StrategyCode strategyCode, ExchangeService exchangeService, CoinType coinType, TradingTerm tradingTerm) {
+        if (strategyCode == StrategyCode.RSI) {
+            return new RsiTradingStrategy(coinType, tradingTerm, exchangeService, strategyAssistant);
+        }
+
+        throw new NoSuchElementException("not found strategy code : " + strategyCode);
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/TradingResult.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/TradingResult.java
@@ -1,0 +1,36 @@
+package com.dingdongdeng.coinautotrading.trading.strategy.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.TradingTag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@ToString
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@RedisHash("tradingResult")
+public class TradingResult {
+
+    @Id
+    @Setter
+    private String id;
+    private String strategyName;
+    private CoinType coinType;
+    private OrderType orderType;
+    private Double volume;
+    private Double price;
+    private PriceType priceType;
+    private String orderId;
+    private TradingTag tag;
+
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/TradingTask.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/TradingTask.java
@@ -1,0 +1,28 @@
+package com.dingdongdeng.coinautotrading.trading.strategy.model;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.type.TradingTag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TradingTask {
+
+    private String strategyName;
+    private CoinType coinType;
+    private OrderType orderType;
+    private Double volume;
+    private Double price;
+    private PriceType priceType;
+    private String orderId;
+    private TradingTag tag; // 주문의 의도를 구분하기 위한 값(ex: 손절 주문, 익절 주문, 매수 주문 등)
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/type/StrategyCode.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/type/StrategyCode.java
@@ -1,0 +1,16 @@
+package com.dingdongdeng.coinautotrading.trading.strategy.model.type;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+public enum StrategyCode {
+    RSI,
+    ;
+
+    public static StrategyCode of(String name) {
+        return Arrays.stream(StrategyCode.values())
+            .filter(type -> type.name().equalsIgnoreCase(name))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(name));
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/type/TradingTag.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/model/type/TradingTag.java
@@ -1,0 +1,14 @@
+package com.dingdongdeng.coinautotrading.trading.strategy.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TradingTag {
+    PROFIT("익절"),
+    LOSS("손절"),
+    BUY("매수");
+
+    private String desc;
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/repository/TradingResultRepository.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/repository/TradingResultRepository.java
@@ -1,0 +1,9 @@
+package com.dingdongdeng.coinautotrading.trading.strategy.repository;
+
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingResult;
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface TradingResultRepository extends CrudRepository<TradingResult, String> {
+
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}) : {%mdc} - %msg%n%throwable
+      </Pattern>
+    </layout>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="Console"/>
+  </root>
+</configuration>

--- a/src/main/resources/private/upbit.yml
+++ b/src/main/resources/private/upbit.yml
@@ -1,2 +1,0 @@
-upbit:
-  key: abcdefg

--- a/src/test/java/com/dingdongdeng/coinautotrading/common/redis/RedisServiceTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/common/redis/RedisServiceTest.java
@@ -1,0 +1,29 @@
+package com.dingdongdeng.coinautotrading.common.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class RedisServiceTest {
+
+    @Autowired
+    private RedisService redisService;
+
+    @Test
+    public void Redis_조회_생성_삭제_테스트() {
+        String key = "test";
+        String value = "test string";
+        redisService.set(key, value);
+        String str = redisService.get(key);
+        redisService.delete(key);
+        String str2 = redisService.get(key);
+
+        assertEquals(value, str);
+        assertEquals(null, str2);
+    }
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/domain/service/TradeTradeOrderServiceTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/domain/service/TradeTradeOrderServiceTest.java
@@ -1,0 +1,27 @@
+package com.dingdongdeng.coinautotrading.domain.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.domain.entity.TradeOrder;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class TradeTradeOrderServiceTest {
+
+    @Autowired
+    private TradeOrderService tradeOrderService;
+
+    @Test
+    public void 저장과_조회_테스트() {
+        TradeOrder savedTradeOrder = tradeOrderService.save(TradeOrder.builder()
+            .orderType(OrderType.BUY)
+            .build());
+        TradeOrder tradeOrder = tradeOrderService.findById(savedTradeOrder.getId());
+        assertEquals(tradeOrder.getId(), savedTradeOrder.getId());
+    }
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitClientTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/exchange/client/UpbitClientTest.java
@@ -1,0 +1,159 @@
+package com.dingdongdeng.coinautotrading.exchange.client;
+
+//import static org.junit.jupiter.api.Assertions.*;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.MarketType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.OrdType;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.Side;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitEnum.State;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.CandleRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.MarketCodeRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderBookRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderCancelRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderChanceRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderInfoListRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderInfoRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.OrderRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitRequest.TickerRequest;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.AccountsResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.CandleResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.MarketCodeResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderBookResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.OrderResponse;
+import com.dingdongdeng.coinautotrading.exchange.client.model.UpbitResponse.TickerResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class UpbitClientTest {
+
+    @Autowired
+    private UpbitClient upbitClient;
+
+    @Test
+    public void 전체_계좌_조회_테스트() {
+        List<AccountsResponse> response = upbitClient.getAccounts();
+        log.info("result : {}", response);
+        AccountsResponse element = response.stream().findFirst().orElse(null);
+        log.info("result of first element : {}", element);
+    }
+
+    @Test
+    public void 마켓_정보_조회_테스트() {
+        MarketCodeRequest request = MarketCodeRequest.builder()
+            .isDetail(true)
+            .build();
+        List<MarketCodeResponse> response = upbitClient.getMarketList(request);
+        log.info("result : {}", response);
+        MarketCodeResponse element = response.stream().findFirst().orElse(null);
+        log.info("result of first element : {}", element);
+    }
+
+    @Test
+    public void 주문_가능_정보_조회_테스트() {
+        OrderChanceRequest request = OrderChanceRequest.builder()
+            .market(MarketType.of(CoinType.ETHEREUM).getCode())
+            .build();
+        log.info("result : {}", upbitClient.getOrdersChance(request));
+    }
+
+    @Test
+    public void 주문_리스트_조회_테스트() {
+        // 리스트 조회
+        OrderInfoListRequest orderInfoListRequest = OrderInfoListRequest.builder()
+            .market("KRW-ETH")
+            .identifierList(null)
+            .state(null)
+            .stateList(List.of(State.wait, State.watch))
+            .page(1)
+            .limit(100)
+            .orderBy("desc")
+            .build();
+        List<OrderResponse> orderInfoListResponse = upbitClient.getOrderInfoList(orderInfoListRequest);
+        log.info("result orderInfoListResponse: {}", orderInfoListResponse);
+    }
+
+    @Test
+    public void 주문과_조회와_취소_테스트() {
+
+        // 주문
+        OrderRequest orderRequest = OrderRequest.builder()
+            .market("KRW-ETH")
+            .side(Side.bid)
+            .volume(1.0)
+            .price(5000.0)
+            .ordType(OrdType.limit)
+            .build();
+        OrderResponse orderResponse = upbitClient.order(orderRequest);
+        log.info("result orderResponse: {}", orderResponse);
+
+        // 조회
+        OrderInfoRequest orderInfoRequest = OrderInfoRequest.builder()
+            .uuid(orderResponse.getUuid())
+            .build();
+        OrderResponse orderInfoResponse = upbitClient.getOrderInfo(orderInfoRequest);
+        log.info("result orderInfoResponse: {}", orderInfoResponse);
+
+        // 리스트 조회
+        OrderInfoListRequest orderInfoListRequest = OrderInfoListRequest.builder()
+            .market("KRW-ETH")
+            .uuidList(List.of(orderInfoResponse.getUuid()))
+            .identifierList(null)
+            .state(null)
+            .stateList(List.of(State.wait, State.watch))
+            .page(1)
+            .limit(100)
+            .orderBy("desc")
+            .build();
+        List<OrderResponse> orderInfoListResponse = upbitClient.getOrderInfoList(orderInfoListRequest);
+        log.info("result orderInfoListResponse: {}", orderInfoListResponse);
+
+        // 취소
+        OrderCancelRequest orderCancelRequest = OrderCancelRequest.builder()
+            .uuid(orderResponse.getUuid())
+            .build();
+        log.info("result orderCancelResponse: {}", upbitClient.orderCancel(orderCancelRequest));
+    }
+
+    @Test
+    public void 분봉_캔들_조회_테스트() {
+        LocalDateTime to = LocalDateTime.of(2022, 01, 13, 21, 9, 0);
+
+        CandleRequest request = CandleRequest.builder()
+            .unit(1)
+            .market("KRW-ETH")
+            .toKst(to)
+            .count(2)
+            .build();
+
+        List<CandleResponse> response = upbitClient.getMinuteCandle(request);
+        log.info("result : {}", response);
+    }
+
+    @Test
+    public void 주문_호가_조회_테스트() {
+        List<OrderBookResponse> response = upbitClient.getOrderBook(
+            OrderBookRequest.builder()
+                .marketList(List.of(MarketType.KRW_ETH.getCode()))
+                .build()
+        );
+        log.info("result : {}", response);
+    }
+
+    @Test
+    public void 현재가_조회_테스트() {
+        List<TickerResponse> response = upbitClient.getTicker(
+            TickerRequest.builder()
+                .marketList(List.of(MarketType.KRW_ETH.getCode()))
+                .build()
+        );
+        log.info("result : {}", response);
+    }
+
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeCandleServiceTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeCandleServiceTest.java
@@ -1,0 +1,35 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+//import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeCandles;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class UpbitExchangeCandleServiceTest {
+
+    @Autowired
+    private UpbitExchangeCandleService service;
+
+    @Test
+    public void 캔들_1분봉_조회_테스트() {
+        LocalDateTime start = LocalDateTime.of(2022, 01, 13, 21, 9, 0);
+        LocalDateTime end = LocalDateTime.of(2022, 01, 13, 21, 19, 0);
+        log.info("start : {}", start);
+        log.info("end : {}", end);
+        ExchangeCandles candles = service.getCandleList(CoinType.ETHEREUM, CandleUnit.UNIT_1M, start, end);
+        log.info("size : {}, candles: {}", candles.getCandleList().size(), candles);
+
+        assertEquals(9, candles.getCandleList().size());
+    }
+
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeServiceTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/exchange/service/UpbitExchangeServiceTest.java
@@ -1,0 +1,57 @@
+package com.dingdongdeng.coinautotrading.exchange.service;
+
+//import static org.junit.jupiter.api.Assertions.*;
+
+import com.dingdongdeng.coinautotrading.common.type.CoinType;
+import com.dingdongdeng.coinautotrading.common.type.OrderType;
+import com.dingdongdeng.coinautotrading.common.type.PriceType;
+import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrder;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancel;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderCancelParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeOrderParam;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfo;
+import com.dingdongdeng.coinautotrading.exchange.service.model.ExchangeTradingInfoParam;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class UpbitExchangeServiceTest {
+
+    @Autowired
+    private UpbitExchangeService processor;
+
+    @Test
+    public void 주문과_조회와_취소_프로세스_테스트() {
+        ExchangeOrderParam exchangeOrderParam = ExchangeOrderParam.builder()
+            .coinType(CoinType.ETHEREUM)
+            .orderType(OrderType.BUY)
+            .volume(1.0)
+            .price(5000.0)
+            .priceType(PriceType.LIMIT_PRICE)
+            .build();
+        ExchangeOrder exchangeOrderResult = processor.order(exchangeOrderParam);
+        log.info("exchangeOrder result : {}", exchangeOrderResult);
+
+        ExchangeOrderCancelParam cancelParam = ExchangeOrderCancelParam.builder()
+            .orderId(exchangeOrderResult.getOrderId())
+            .build();
+        ExchangeOrderCancel cancelResult = processor.orderCancel(cancelParam);
+        log.info("exchangeCancel result : {}", cancelResult);
+    }
+
+    @Test
+    public void 거래를_위한_정보_생성_테스트() {
+        ExchangeTradingInfo exchangeTradingInfo = processor.getTradingInformation(
+            ExchangeTradingInfoParam.builder()
+                .coinType(CoinType.ETHEREUM)
+                .tradingTerm(TradingTerm.SCALPING)
+                .build()
+        );
+        log.info("exchangeTradingInfo result : {}", exchangeTradingInfo);
+    }
+
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/trading/domain/DataSourceTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/trading/domain/DataSourceTest.java
@@ -1,0 +1,22 @@
+package com.dingdongdeng.coinautotrading.trading.domain;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@Slf4j
+@DataJpaTest
+public class DataSourceTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void DB커넥션_테스트() throws Exception {
+        Connection con = dataSource.getConnection();
+        log.info("driver name : {}", con.getMetaData().getDriverName());
+    }
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/trading/strategy/RsiTradingStrategyTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/trading/strategy/RsiTradingStrategyTest.java
@@ -1,0 +1,29 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+//import static org.junit.jupiter.api.Assertions.*;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class RsiTradingStrategyTest {
+
+    @Test
+    public void RSI_높을때_테스트() {
+
+    }
+
+    @Test
+    public void RSI_낮을때_테스트() {
+
+    }
+
+    @Test
+    public void RSI_보통일때_테스트() {
+
+    }
+
+
+}

--- a/src/test/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/trading/strategy/StrategyTest.java
@@ -1,0 +1,24 @@
+package com.dingdongdeng.coinautotrading.trading.strategy;
+
+import com.dingdongdeng.coinautotrading.exchange.service.UpbitExchangeService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class StrategyTest {
+
+    @Autowired
+    private UpbitExchangeService upbitExchangeProcessor;
+
+    @Test
+    public void Prototype_테스트() { //fixme Mock을 이용해서 테스트 고도화(TDD)
+//        Strategy strategy = new RsiTradingStrategy(CoinType.ETHEREUM, TradingTerm.SCALPING, upbitExchangeProcessor);
+        //log.info("orderTask : {}", strategy.execute());
+        //log.info("orderTask : {}", strategy.execute());
+        //log.info("orderTask : {}", strategy.execute());
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,6 +10,9 @@ upbit:
     connectionTimeout: 5000
 
 spring:
+  profiles:
+    active: test
+
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
* upbit.yml을 dev, release로 스켈레톤 생성

* console 출력 로그백 설정

* build.gradle webflux추가

* application.yml 포트 8080 정의

* yml 파일 정리

* AdminController 스켈레톤 생성

* 관리자 명령어 실행을 위한 /upbit/command api 생성

* admin 도메인 스켈레톤 생성

* application 공통 config 생성

* UpbitClient를 설정 및 스켈레톤 생성

* upbit yml파일 수정(baseUrl, accessKey, secretKey)

* upbit yml 파일 수정2

* ClientResourceProperties accessKey, secretKey 추가

* build.gradle jwt 의존성 추가

* 전체 계좌 조회 api 추가

* ApiResponseException 생성

* WebClientConfig 리팩토링

* UpbitClient 조회 api 추가(마켓 정보 조회, 주문 가능 정보 조회)

* UpbitClient 응답모델 사용하도록 수정

* token 생성 로직 리팩토링

* QueryParamsConverter 생성

* UpbitRequest을 사용하도록 UpbitClient 수정 및 리팩토링

* upbit 패키지 exchange(거래소) 패키지 하위로 이동

* 주문 api 추가

* upbit jwt 토큰 생성로직 리팩토링

* 주문 취소 api 추가

* String으로 관리하던 타입을 enum으로 수정

* admin 패키지를 autotrading패키지로 수정

* adminHttpRequests.http 생성

* admin 패키지를 다시 추가

* CoinExchangeType을 common 패키지로 이동(패키지 의존 관계 고려)

* ControllerExceptionHandler 오타 수정

* 거래서 종류별로 구성한 패키지 구조를 수정

* AdminController, AdminService 생성

* AutoTradingService 생성

* AdminService, AutoTradingService 리팩토링

* Upbit에서 사용하는 이넘을 UpbitEnum 클래스로 관리

* ExchangeProcessor, ExchangeProcessorSelector 생성

* Strategy, StrategyCode, StrategyFactory 생성

* PrototypeStrategy, Prototype2Strategy 생성

* UpbitExchangeProcessor 생성

* 파라미터로 strategy(전략)을 받을 수 있도록 수정

* OrderType 생성

* Strategy 클래스 execute()를 코어한 메소드로 사용하도록 수정

what(), how(), when()만 구현해서 사용할 수 있도록하기 위함

* test를 위한 임시 코드 작성

* 불필요 메소드 제거

* upbit 관련 model 패키지 이동

* upbit 주문 조회 api 추가

* ExchangeProcessor에서 사용하기 위한 모델 클래스 생성

* StrategyCode 패키지 이동

* Strategy 관련 로직 리팩토링

* enum 타입에 of() 메소드 추가

* Client 오류 수정

* mdc 로깅을 위한 LoggingUtils 생성 및 logback 포멧 수정

* WebClientConfig에 로깅 강화(mdc 로깅, req/res 로깅)

* webClient 로깅 오류 수정

* LoggingFilter 추가

* AsyncConfig 생성

* 업비트 주문 취소 api 응답값 데이터타입 수정

* Process 관련 모델들에 일단 upbit api응답값 저장(이후에 최적화 필요)

* OrderType -> TaskType으로 변경

* OrderType, PriceType 이넘 생성

* UpbitEnum 수정

* UpbitResponse 이넘타입 사용 가능한 필드들 수정

* UpbitREsponse 오타 수정

* UpbitClientTest 관리 가능한 테스트만 실행되도록 수정

* UpbitExchangeProcessor.order() 메소드 작성

* 주문 조회, 주문 취소 process 작성

* ProcessAccountParam 불필요 필드 제거

* Client에 ParameterizedTypeReference<T> 반영

* UpbitExchangeProcessor에 계좌조회 로직 구현

* UpbitClientTest 개선

* fixme 주석 추가

* OrderType을 매도,매수,취소 의 공통 이넘으로 사용하도록 수정

* marketId -> cointType으로 수정

* CoinType을 이넘으로 관리 및 이를 위한 관련 코드 추가

* 오류 수정

* build.gradle fixme주석 추가

* What -> OrderTask 로 수정

* fixme 주석 추가

* Strategy.makeOrderTask() 를 구현하여 로직이 동작하도록 수정

* OrderState 이넘 추가 및 로직에 반영

* application.yml에 h2database, embedded-redis 추가

* ExchangeOrderRepository 생성

* gradle 의존성에 undertow, h2database, embedded-redis 추가

* ExchangeOrderComponent 생성

* 로그 보강

* 누락된 ExchangeOrder 컬럼 추가

* Strategy에 미체결 주문 관련 로직 구현

* Upbit 캔들조회 api 추가

* ExchangeProcessor에 getCandelList() 메소드 추가

* log 추가

* 주문 상태 이넘 수정

* QueryParamsConverter, UpbitTokenGenerator 배열파라미터 다룰수 있도록 수정

* QueryParamsConverter, UpbitTokenGenerator 리팩토링

* Upbit 주문 리스트 조회 api 추가

* admin command 요청을 post로 받고 다양한 파라미터를 받도록 수정

* AutoTradingService에서 AutoTradingStartParam 사용하도록 수정

* Strategy에서 CointType과 TradingTerm을 상태로 갖도록 수정

* Strategy에서 CointType과 TradingTerm을 상태로 갖도록 수정2

* ExchangeProcessor에서 불필요한 메소드를 없애고 추상화수준을 맞춘 새 메소드 생성 및 관련 로직 수정

* Process의 결과를 의미하는 모델의 이름을 ProcessedXXXX로 수정

* 로그 내용 수정

* 패키지명 autotrading -> trading으로 변경

* autotrading 패키지를 trading패키지 안으로 이동

* CommandRequest 클래스 model 패키지 안으로 이동

* ExchangeProcessor 관련을 ExchangeService로 모두 변경

* ExchangeOrder 엔티티를 Trading으로 명칭 변경하고, 관련 내용들도 모두 Trading으로 수정

* 보조지표 계산을 위한 IndexCalculator 추가

* 누락된 네이밍 변경 사항들 반영

* 캔들 조회 api 메소드명 수정

* CandleUnit 생성 및 로직에 반영

* 누락된 네이밍 변경사항 반영

* 보조 지표 계산의 책임을 exchange 패키지로 위임

* build.gradle 쿼츠 추가

* trading.domain 패키지를 한단계 상위 패키지로 변경

* 거래소 차트 정보 적재를 위한 스케쥴러 및 레포지토리 서비스 스켈레톤 생성

* Trading 엔티티 관련 -> ExchangeOrder로 명칭 변경

* domain 패키지의 엔티티 명칭을 Candle, TradeOrder로 확정

* 불필요 필드 제거

* UpbitCandleStoreJob이 UpbitClient를 의존하도록 수정

* ExchangeCandleService와 Upbit 구현체 스켈레톤 생성

* CandleStoreJob이 ExchangeCandleService를 의존하도록 수정

* CandleStoreJob 기본적인 로직만 작성

* 변수명 오타 수정

* 변수명 오타 수정

* CandleStoreJob에서 사용하기 위한 ExchangeCandleService 구현

* UpbitExchangeCandleService CandleUnit을 고려한 로직 추가

* CandleStoreJob이 DB에 캔들 저장하도록 수정

* Candle 컬럼 추가

* Candle에 CoinExchangeType추가(거래소타입)

* CandleStoreJob LIMIT_DAYS 필드 추가

* Candle 컬럼명 수정

* Candle 조회 시 거래소타입을 사용하도록 수정

* h2 console 프로퍼티 추가

* application-test.yml 생성

* test할때는 배치 동작안하도록 수정

* test 모듈의 application-test.yml, logback.xml 제거

main 모듈의 yml,xml 파일을 읽어서 사용중이기 때문에 제거했음

* TradingTerm 추가

* test application.yml 다시 추가

* OrderBook req, res 추가

* UpbitClient에 주문 호가 조회 api 추가

* UpbitClient에 현재가 조회 api 추가

* IndexCalculator에 rsi 계산 로직 추가

* 현재가 정보를 ExchangeTradingInfo에 추가

ExchangeTicker 모델 추가
모델 생성 로직 추가

* fixme 주문호가, 현재가 조회 api에서 markets 파라미터가 인식 안되는 문제때문에 단일 요청하도록 수정

* 주문호가, 현재가 조회 api에서 markets 파라미터가 안되던 이슈 해결

* TradingInfo를 제거하고 Strategy에서 ExchangeTradingInfo를 참조하도록 수정

어차피 의존성이 서로 강한 얘들이기 떄문

* TradingTask 생성자 추가

* 주문 생성일 필드 String -> LocalDateTime 으로 수정

* ExchangeTradingInfo @Builder.Default 사용

* Strategy에서 List<TradingTask>를 핸들링 하도록 로직 수정

더 유여한 알고리즘 구현을 위해

* 잘못된 업비트 거래소 관련 모델 수정

* UpbitResponse에서 @JsonFormat 패턴 수정

* TradingTask 주석 추가

* TradingTask에 tag필드 추가

* Strategy에서 주문의 결과를 핸들링 할수 있도록 handleOrderResult 메소드 추가

* TradingTag enum 생성

* common 패키지 구조 수정

* LoggingUtils에 @UtilityClass 추가

* redis 사용을 위한 설정 및 클래스 추가

* RedisService 기본 expires 기간 설정

* redis를 repository로 이용하기 위한 설정 추가

* 잘못된 import 수정

* TradingResult 생성하면서 TradingTask에 있던 레디스 저장을 위한 코드 제거

* TradingResultRepository 생성

* StrategyAssistant 생성

* Strategy에서 TradingResult에 결과값을 넣도록 수정

* StrategyFactory에서 StrategyAssistant를 RsiTradingStrategy에 넣어주도록 수정

* RsiTradingStrategy 매매 알고리즘 작성

* 잘못된 import 수정

* application.yml의 accessKey, secretKey를 환경변수로 사용하도록 수정

* 오류나는 테스트 주석처리

* 로그 수정

* 쿼츠 동작 안하도록 주석 처리