### PR TITLE
Feature/임시 콘솔 고도화 (#60)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,9 +86,10 @@ jobs:
       - name: Slack notification
         uses: 8398a7/action-slack@v3
         with:
+          username: github action
           status: ${{ job.status }}
           author_name: Github Action
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          fields: repo,message,commit # repo,message,commit,author,action,eventName,ref,workflow,job,took
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-web') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-undertow'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/dingdongdeng/coinautotrading/auth/config/SecurityConfig.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/auth/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.dingdongdeng.coinautotrading.auth.config;
+
+import com.dingdongdeng.coinautotrading.auth.service.UserService;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final UserService userService;
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/css/**", "/js/**", "/img/**", "/actuator/health");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+            .authorizeRequests()
+            .antMatchers("/login").permitAll()
+            .antMatchers("/**").authenticated()
+            .and()
+
+            .formLogin()
+            .loginPage("/login")
+            .usernameParameter("userId")
+            .passwordParameter("password")
+            .loginProcessingUrl("/login")
+            .successHandler(new LoginSuccessHandler())
+            .and()
+
+            .logout()
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/login")
+            .invalidateHttpSession(true)
+            .deleteCookies()
+            .and()
+
+            .csrf()
+            .disable();
+    }
+
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userService).passwordEncoder(new BCryptPasswordEncoder());
+    }
+
+    private class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+        @Override
+        public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+            HttpSession session = request.getSession();
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            session.setAttribute("userId", userDetails.getUsername());
+            response.sendRedirect("/");
+        }
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/auth/controller/KeyController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/auth/controller/KeyController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,7 +24,7 @@ public class KeyController {
     private final KeyService keyService;
 
     @GetMapping("/user/{userId}/key/pair")
-    public CommonResponse<List<KeyPairResponse>> getKeyList(@PathVariable String userId) {
+    public CommonResponse<List<KeyPairResponse>> getKeyList(@SessionAttribute String userId) {
         return CommonResponse.<List<KeyPairResponse>>builder()
             .body(keyService.getUserKeyList(userId))
             .message("key get success")
@@ -32,7 +32,7 @@ public class KeyController {
     }
 
     @PostMapping("/key/pair")
-    public CommonResponse<List<KeyPairResponse>> registerKey(@Valid @RequestBody KeyPairRegisterRequest request, @RequestHeader String userId) {
+    public CommonResponse<List<KeyPairResponse>> registerKey(@Valid @RequestBody KeyPairRegisterRequest request, @SessionAttribute String userId) {
         return CommonResponse.<List<KeyPairResponse>>builder()
             .body(keyService.register(request, userId))
             .message("key register success")
@@ -40,7 +40,7 @@ public class KeyController {
     }
 
     @DeleteMapping("/key/pair/{keyPairId}")
-    public CommonResponse<List<KeyPairResponse>> deleteKey(@PathVariable String keyPairId, @RequestHeader String userId) {
+    public CommonResponse<List<KeyPairResponse>> deleteKey(@PathVariable String keyPairId, @SessionAttribute String userId) {
         return CommonResponse.<List<KeyPairResponse>>builder()
             .body(keyService.deleteKeyPair(keyPairId, userId))
             .message("key register success")

--- a/src/main/java/com/dingdongdeng/coinautotrading/auth/controller/UserController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/auth/controller/UserController.java
@@ -1,0 +1,15 @@
+package com.dingdongdeng.coinautotrading.auth.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Slf4j
+@Controller
+public class UserController {
+
+    @GetMapping("/login")
+    public String loginPage() {
+        return "login";
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/auth/service/UserService.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/auth/service/UserService.java
@@ -1,0 +1,26 @@
+package com.dingdongdeng.coinautotrading.auth.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        //fixme 고도화 필요
+        String adminName = "admin";
+        String password = new BCryptPasswordEncoder().encode("1234");
+        if (!username.equals(adminName)) {
+            throw new UsernameNotFoundException("User not authorized.");
+        }
+        return new User(username, password, List.of());
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/console/controller/ConsoleController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/console/controller/ConsoleController.java
@@ -5,6 +5,7 @@ import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
 import com.dingdongdeng.coinautotrading.common.type.CoinType;
 import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
 import com.dingdongdeng.coinautotrading.console.controller.model.TypeInfoResponse;
+import com.dingdongdeng.coinautotrading.console.controller.model.TypeInfoResponse.TypeInfoTemplate;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.type.StrategyCode;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,14 +26,15 @@ public class ConsoleController {
         return CommonResponse.<TypeInfoResponse>builder()
             .body(
                 TypeInfoResponse.builder()
-                    .coinTypeMap(CoinType.toMap())
-                    .coinExchangeTypeMap(CoinExchangeType.toMap())
-                    .tradingTermMap(TradingTerm.toMap())
-                    .strategyCodeMap(StrategyCode.toMap())
+                    .coinTypeList(TypeInfoTemplate.listOf(CoinType.toMap()))
+                    .coinExchangeTypeList(TypeInfoTemplate.listOf(CoinExchangeType.toMap()))
+                    .tradingTermList(TypeInfoTemplate.listOf(TradingTerm.toMap()))
+                    .strategyCodeList(TypeInfoTemplate.listOf(StrategyCode.toMap()))
                     .build()
             )
             .message("get type info success")
             .build();
     }
+
 
 }

--- a/src/main/java/com/dingdongdeng/coinautotrading/console/controller/model/TypeInfoResponse.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/console/controller/model/TypeInfoResponse.java
@@ -1,10 +1,8 @@
 package com.dingdongdeng.coinautotrading.console.controller.model;
 
-import com.dingdongdeng.coinautotrading.common.type.CoinExchangeType;
-import com.dingdongdeng.coinautotrading.common.type.CoinType;
-import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
-import com.dingdongdeng.coinautotrading.trading.strategy.model.type.StrategyCode;
-import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +16,25 @@ import lombok.ToString;
 @Builder
 public class TypeInfoResponse {
 
-    private EnumMap<CoinType, String> coinTypeMap;
-    private EnumMap<CoinExchangeType, String> coinExchangeTypeMap;
-    private EnumMap<TradingTerm, String> tradingTermMap;
-    private EnumMap<StrategyCode, String> strategyCodeMap;
+    private List<TypeInfoTemplate> coinTypeList;
+    private List<TypeInfoTemplate> coinExchangeTypeList;
+    private List<TypeInfoTemplate> tradingTermList;
+    private List<TypeInfoTemplate> strategyCodeList;
+
+    @ToString
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TypeInfoTemplate {
+
+        private String name;
+        private Object value;
+
+        public static List<TypeInfoTemplate> listOf(Map<?, String> enumMap) {
+            return enumMap.entrySet().stream()
+                .map(entry -> new TypeInfoTemplate(entry.getValue(), entry.getKey()))
+                .collect(Collectors.toList());
+        }
+    }
 }

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/controller/AutoTradingController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/autotrading/controller/AutoTradingController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class AutoTradingController {
     private final AutoTradingAggregation autoTradingAggregation;
 
     @GetMapping("/user/{userId}/autotrading")
-    public CommonResponse<List<AutoTradingResponse>> getList(@PathVariable String userId) {
+    public CommonResponse<List<AutoTradingResponse>> getList(@SessionAttribute String userId) {
         return CommonResponse.<List<AutoTradingResponse>>builder()
             .body(autoTradingAggregation.getUserProcessorList(userId))
             .message("autotrading get list success")
@@ -31,7 +31,7 @@ public class AutoTradingController {
     }
 
     @PostMapping("/autotrading/register")
-    public CommonResponse<AutoTradingResponse> register(@Valid @RequestBody AutoTradingRegisterRequest request, @RequestHeader String userId) {
+    public CommonResponse<AutoTradingResponse> register(@Valid @RequestBody AutoTradingRegisterRequest request, @SessionAttribute String userId) {
         return CommonResponse.<AutoTradingResponse>builder()
             .body(autoTradingAggregation.register(request, userId))
             .message("autotrading register success")
@@ -39,7 +39,7 @@ public class AutoTradingController {
     }
 
     @PostMapping("/autotrading/{autoTradingProcessorId}/start")
-    public CommonResponse<AutoTradingResponse> start(@PathVariable String autoTradingProcessorId, @RequestHeader String userId) {
+    public CommonResponse<AutoTradingResponse> start(@PathVariable String autoTradingProcessorId, @SessionAttribute String userId) {
         return CommonResponse.<AutoTradingResponse>builder()
             .body(autoTradingAggregation.start(autoTradingProcessorId, userId))
             .message("autotrading start success")
@@ -47,7 +47,7 @@ public class AutoTradingController {
     }
 
     @PostMapping("/autotrading/{autoTradingProcessorId}/stop")
-    public CommonResponse<AutoTradingResponse> stop(@PathVariable String autoTradingProcessorId, @RequestHeader String userId) {
+    public CommonResponse<AutoTradingResponse> stop(@PathVariable String autoTradingProcessorId, @SessionAttribute String userId) {
         return CommonResponse.<AutoTradingResponse>builder()
             .body(autoTradingAggregation.stop(autoTradingProcessorId, userId))
             .message("autotrading stop success")
@@ -55,7 +55,7 @@ public class AutoTradingController {
     }
 
     @PostMapping("/autotrading/{autoTradingProcessorId}/terminate")
-    public CommonResponse<AutoTradingResponse> terminate(@PathVariable String autoTradingProcessorId, @RequestHeader String userId) {
+    public CommonResponse<AutoTradingResponse> terminate(@PathVariable String autoTradingProcessorId, @SessionAttribute String userId) {
         return CommonResponse.<AutoTradingResponse>builder()
             .body(autoTradingAggregation.terminate(autoTradingProcessorId, userId))
             .message("autotrading terminate success")

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/backtesting/controller/BackTestingController.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/backtesting/controller/BackTestingController.java
@@ -8,11 +8,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,7 +21,7 @@ public class BackTestingController {
     private final BackTestingAggregation backTestingAggregation;
 
     @PostMapping("/backtesting")
-    public CommonResponse<BackTestingResponse> doTest(@RequestBody BackTestingRequest.Register request, @RequestHeader String userId) {
+    public CommonResponse<BackTestingResponse> doTest(@RequestBody BackTestingRequest.Register request, @SessionAttribute String userId) {
         return CommonResponse.<BackTestingResponse>builder()
             .body(backTestingAggregation.doTest(request, userId))
             .message("backtesting doTest success")
@@ -30,7 +29,7 @@ public class BackTestingController {
     }
 
     @GetMapping("/user/{userId}/backtesting")
-    public CommonResponse<List<BackTestingResponse>> getResult(@PathVariable String userId) {
+    public CommonResponse<List<BackTestingResponse>> getResult(@SessionAttribute String userId) {
         return CommonResponse.<List<BackTestingResponse>>builder()
             .body(backTestingAggregation.getResult(userId))
             .message("backtesting getResult success")

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,204 +4,341 @@
 <head>
   <meta charset="UTF-8">
   <link rel="icon" th:href="@{favicon.ico(v=2)}"/>
-  <title>Title</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <title>Dashboard</title>
 </head>
 <body>
-<div id="app">
-  <div>
-    <h1>임시 사용자 콘솔 화면</h1>
-  </div>
-  <div>
-    <div>
-      <span>사용자 ID : </span>
-      <input v-model="user.id" type="text">
-      <input type="button" value="업데이트" @click="updateAllInformation()">
-    </div>
-  </div>
-  <div>
-    <div>
-      <input type="button" value="키 등록" @click="toggleKeyRegisterUI()">
-      <input type="button" value="자동매매 등록" @click="toggleAutoTradingRegisterUI()">
-    </div>
-    <div v-if="register.keyPair.isVisible">
-      <h3> 키 등록</h3>
-      <select v-model="register.keyPair.coinExchangeType">
-        <option disabled value="">거래소</option>
-        <option v-for="(value,key) in type.coinExchangeTypeMap" :value="key">{{value}}</option>
-      </select>
-      <div v-for="(key, i) in register.keyPair.keyList">
-        <input v-model="key.name" type="text" placeholder="키 이름">
-        <input v-model="key.value" type="text" placeholder="키 값">
-        <input type="button" value="x" @click="deleteKeyInputBox(i)">
-      </div>
-      <div>
-        <input type="button" value="+" @click="addKeyInputBox()">
-      </div>
-      <div>
-        <input type="button" value="등록하기" @click="registerKeyPair(refresh)">
-      </div>
-    </div>
-    <div v-if="register.autoTrading.isVisible">
-      <h3> 자동 매매 등록</h3>
-      <div>
-        <input v-model="register.autoTrading.title" type="text" placeholder="제목">
-      </div>
-      <div>
-        <select v-model="register.autoTrading.coinType">
-          <option disabled value="">코인 종목</option>
-          <option v-for="(value,key) in type.coinTypeMap" :value="key">{{value}}</option>
-        </select>
-      </div>
-      <div>
-        <select v-model="register.autoTrading.coinExchangeType">
-          <option disabled value="">거래소</option>
-          <option v-for="(value,key) in type.coinExchangeTypeMap" :value="key">{{value}}</option>
-        </select>
-      </div>
-      <div>
-        <select v-model="register.autoTrading.tradingTerm">
-          <option disabled value="">매매 전략</option>
-          <option v-for="(value,key) in type.tradingTermMap" :value="key">{{value}}</option>
-        </select>
-      </div>
-      <div>
-        <select v-model="register.autoTrading.strategyCode">
-          <option disabled value="">전략 코드</option>
-          <option v-for="(value,key) in type.strategyCodeMap" :value="key">{{value}}</option>
-        </select>
-      </div>
-      <div>
+<v-app id="app">
+
+  <!-- 헤더 -->
+  <v-container>
+    <v-toolbar dark color="primary" style="height:5vh;">
+      <v-toolbar-title class="white--text"></v-toolbar-title>
+
+      <v-toolbar-items>
+        <v-icon @click="refresh()">cached</v-icon>
+      </v-toolbar-items>
+
+      <v-spacer></v-spacer>
+
+      <v-form action="/logout" method="post">
+        <v-btn
+            type="submit"
+            text
+        >Logout
+        </v-btn>
+      </v-form>
+    </v-toolbar>
+  </v-container>
+
+  <!-- 모달 -->
+  <v-dialog
+      v-model="register.backTesting.isVisible"
+      width="500"
+  >
+    <v-card>
+      <v-toolbar dark color="primary">
+        <v-toolbar-title>백테스팅 실행</v-toolbar-title>
+      </v-toolbar>
+      <v-card-text>
         <div>
-          <input v-model="register.autoTrading.buyRsi" type="text" placeholder="매수 주문을 할 rsi 기준">
+          시작일 : <input type="datetime-local" v-model="register.backTesting.start">
         </div>
         <div>
-          <input v-model="register.autoTrading.profitRsi" type="text" placeholder="이익중일때 익절할 rsi 기준">
+          종료일 : <input type="datetime-local" v-model="register.backTesting.end">
         </div>
-        <div>
-          <input v-model="register.autoTrading.lossRsi" type="text" placeholder="손실중일때 손절할 rsi 기준">
-        </div>
-        <div>
-          <input v-model="register.autoTrading.profitLimitPriceRate" type="text" placeholder="익절 이익율 상한">
-        </div>
-        <div>
-          <input v-model="register.autoTrading.lossLimitPriceRate" type="text" placeholder="손절 손실율 상한">
-        </div>
-        <div>
-          <input v-model="register.autoTrading.tooOldOrderTimeSeconds" type="text" placeholder="초(second)">
-        </div>
-        <div>
-          <input v-model="register.autoTrading.orderPrice" type="text" placeholder="한번에 주문할 금액">
-        </div>
-        <div>
-          <input v-model="register.autoTrading.accountBalanceLimit" type="text" placeholder="계좌 금액 안전 장치">
-        </div>
-      </div>
-      <div>
-        <input v-model="register.autoTrading.keyPairId" type="text" placeholder="키 페어 ID">
-      </div>
-      <div>
-        <input type="button" value="등록하기" @click="registerAutoTrading(refresh)">
-      </div>
-    </div>
-    <div v-if="register.backTesting.isVisible">
-      <input type="datetime-local" v-model="register.backTesting.start">
-      <input type="datetime-local" v-model="register.backTesting.end">
-      <input type="button" value="실행" @click="registerBackTesting(register.backTesting.autoTradingProcessorId, register.backTesting.start, register.backTesting.end, refresh)">
-    </div>
-  </div>
-  <div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+            @click="registerBackTesting(register.backTesting.autoTradingProcessorId, register.backTesting.start, register.backTesting.end, refresh)"
+        > 실행
+        </v-btn>
+        <v-btn
+            @click="toggleBackTestingRegisterUI()"
+        > 취소
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <!-- 키 리스트 -->
+  <v-container>
     <h2> 키 리스트 </h2>
-    <div v-for="keyPair in user.keyPairList">
-      <div>
-        <div>
-          키 페어 ID : {{keyPair.pairId}}
-        </div>
-        <div>
-          거래소 : {{keyPair.coinExchangeType}}
-        </div>
-        <div v-for="key in keyPair.keyList">
-          <div>
-            키 이름 : {{key.name}}
-          </div>
-        </div>
-        <div>
-          <input type="button" value="삭제" @click="deleteUserPairKey(keyPair.pairId, refresh)">
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <h2> 자동매매 리스트 </h2>
-    <div v-for="autoTrading in user.autoTradingList">
-      <div>
-        제목 : {{autoTrading.title}}
-      </div>
-      <div>
-        전략 코드 : {{autoTrading.strategyIdentifyCode}}
-      </div>
-      <div>
-        매매 타입 : {{autoTrading.tradingTerm}}
-      </div>
-      <div>
-        거래소 : {{autoTrading.coinExchangeType}}
-      </div>
-      <div>
-        코인 : {{autoTrading.coinType}}
-      </div>
-      <div>
-        프로세스ID : {{autoTrading.processorId}}
-      </div>
-      <div>
-        상태 : {{autoTrading.processStatus}}
-      </div>
-      <div>
-        세부설정 : {{autoTrading}}
-      </div>
-      <div>
-        백테스팅 현황
-        <div v-for="backTesting in user.backTestingList">
-          <div v-if="backTesting.autoTradingProcessorId==autoTrading.processorId">
+    <v-row justify="start">
+      <v-col
+          cols="3"
+          v-for="keyPair in user.keyPairList"
+      >
+        <v-card
+            class="ma-3"
+        >
+          <v-card-text>
             <div>
-              기간 : {{backTesting.start}} ~ {{backTesting.end}}
+              키 페어 ID : {{keyPair.pairId}}
             </div>
             <div>
-              실행율 : {{backTesting.result.executionRate}}
+              거래소 : {{keyPair.coinExchangeType}}
             </div>
-            <div>
-              상태 : {{backTesting.result.status}}
-            </div>
-            <div>
-              손익 : {{backTesting.result.marginPrice}}
-            </div>
-            <div>
-              손익율 : {{backTesting.result.marginRate}}
-            </div>
-            <div>
-              수수료 : {{backTesting.result.totalFee}}
-            </div>
-            <div>
-              히스토리 :
-              <div v-html="backTesting.result.eventMessage">
+            <div v-for="key in keyPair.keyList">
+              <div>
+                키 이름 : {{key.name}}
               </div>
             </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn
+                color="primary"
+                @click="deleteUserPairKey(keyPair.pairId, refresh)"
+            > 삭제
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+      <v-col cols="3">
+        <v-card class="ma-3">
+          <v-card-text>
             <div>
+              <v-select
+                  label="거래소를 선택해주세요."
+                  solo
+                  :items="type.coinExchangeTypeList"
+                  item-text="name"
+                  item-value="value"
+                  v-model="register.keyPair.coinExchangeType"
+              ></v-select>
+              <v-row
+                  align="center"
+                  justify="center"
+                  v-for="(key, i) in register.keyPair.keyList"
+              >
+                <v-col cols="4">
+                  <v-text-field
+                      label="키 이름"
+                      v-model="key.name"
+                  ></v-text-field>
+                </v-col>
+                <v-col cols="6">
+                  <v-text-field
+                      label="키 값"
+                      v-model="key.value"
+                  ></v-text-field>
+                </v-col>
+                <v-col cols="2">
+                  <v-icon @click="deleteKeyInputBox(i)">delete</v-icon>
+                </v-col>
+              </v-row>
+              <v-icon
+                  x-large
+                  @click="addKeyInputBox()"
+              >add_circle
+              </v-icon>
+            </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn value="" @click="registerKeyPair(refresh)">키 등록</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+
+  <!-- 자동매매 리스트 -->
+  <v-container>
+    <h2> 자동매매 리스트 </h2>
+    <v-row justify="start">
+      <v-col
+          cols="4"
+          v-for="autoTrading in user.autoTradingList"
+      >
+        <v-card
+            class="ma-3"
+        >
+          <v-card-text>
+            <div>
+              제목 : {{autoTrading.title}}
+            </div>
+            <div>
+              전략 코드 : {{autoTrading.strategyIdentifyCode}}
+            </div>
+            <div>
+              매매 타입 : {{autoTrading.tradingTerm}}
+            </div>
+            <div>
+              거래소 : {{autoTrading.coinExchangeType}}
+            </div>
+            <div>
+              코인 : {{autoTrading.coinType}}
+            </div>
+            <div>
+              프로세스ID : {{autoTrading.processorId}}
+            </div>
+            <div>
+              상태 : {{autoTrading.processStatus}}
+            </div>
+
+            <div>
+              <v-expansion-panels>
+                <v-expansion-panel>
+                  <v-expansion-panel-header>
+                    세부설정
+                  </v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <pre style="white-space: pre-wrap">
+                      {{JSON.stringify(autoTrading, null, 4)}}
+                    </pre>
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+                <v-expansion-panel
+                    v-for="backTesting in user.backTestingList"
+                >
+                  <v-expansion-panel-header>
+                    백테스팅 현황
+                  </v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    <div>
+                      <div v-if="backTesting.autoTradingProcessorId==autoTrading.processorId">
+                        <div>
+                          기간 : {{backTesting.start}} ~ {{backTesting.end}}
+                        </div>
+                        <div>
+                          실행율 : {{backTesting.result.executionRate}}
+                        </div>
+                        <div>
+                          상태 : {{backTesting.result.status}}
+                        </div>
+                        <div>
+                          손익 : {{backTesting.result.marginPrice}}
+                        </div>
+                        <div>
+                          손익율 : {{backTesting.result.marginRate}}
+                        </div>
+                        <div>
+                          수수료 : {{backTesting.result.totalFee}}
+                        </div>
+                        <div>
+                          히스토리 :
+                          <div v-html="backTesting.result.eventMessage"></div>
+                        </div>
+                      </div>
+                    </div>
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+              </v-expansion-panels>
 
             </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <input type="button" value="시작" @click="startAutoTrading(autoTrading.processorId,refresh)">
-        <input type="button" value="정지" @click="stopAutoTrading(autoTrading.processorId,refresh)">
-        <input type="button" value="종료" @click="terminateAutoTrading(autoTrading.processorId,refresh)">
-        <input type="button" value="백테스팅" @click="toggleBackTestingRegisterUI(autoTrading.processorId)">
-      </div>
-    </div>
-  </div>
-</div>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn @click="startAutoTrading(autoTrading.processorId,refresh)"> 시작</v-btn>
+            <v-btn @click="stopAutoTrading(autoTrading.processorId,refresh)"> 정지</v-btn>
+            <v-btn @click="terminateAutoTrading(autoTrading.processorId,refresh)"> 종료</v-btn>
+            <v-btn @click="toggleBackTestingRegisterUI(autoTrading.processorId)"> 백테스팅</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+      <v-col cols="4">
+        <v-card class="ma-3">
+          <v-card-text>
+            <v-text-field
+                label="자동 매매 이름을 입력해주세요."
+                v-model="register.autoTrading.title"
+            ></v-text-field>
+            <v-select
+                label="코인 종목을 선택해주세요."
+                solo
+                :items="type.coinTypeList"
+                item-text="name"
+                item-value="value"
+                v-model="register.autoTrading.coinType"
+            ></v-select>
+            <v-select
+                label="거래소를 선택해주세요."
+                solo
+                :items="type.coinExchangeTypeList"
+                item-text="name"
+                item-value="value"
+                v-model="register.autoTrading.coinExchangeType"
+            ></v-select>
+            <v-select
+                label="매매 전략을 선택해주세요."
+                solo
+                :items="type.tradingTermList"
+                item-text="name"
+                item-value="value"
+                v-model="register.autoTrading.tradingTerm"
+            ></v-select>
+            <v-select
+                label="전략 코드를 선택해주세요."
+                solo
+                :items="type.strategyCodeList"
+                item-text="name"
+                item-value="value"
+                v-model="register.autoTrading.strategyCode"
+            ></v-select>
+            <v-text-field
+                label="매수 주문을 할 rsi 기준을 입력해주세요."
+                v-model="register.autoTrading.buyRsi"
+            ></v-text-field>
+            <v-text-field
+                label="이익중일때 익절할 rsi 기준을 입력해주세요."
+                v-model="register.autoTrading.profitRsi"
+            ></v-text-field>
+            <v-text-field
+                label="손실중일때 손절할 rsi 기준을 입력해주세요."
+                v-model="register.autoTrading.lossRsi"
+            ></v-text-field>
+            <v-text-field
+                label="익절 이익율 상한을 입력해주세요."
+                v-model="register.autoTrading.profitLimitPriceRate"
+            ></v-text-field>
+            <v-text-field
+                label="손절 손실율 상한을 입력해주세요."
+                v-model="register.autoTrading.lossLimitPriceRate"
+            ></v-text-field>
+            <v-text-field
+                label="지연 시간(second)을 입력해주세요."
+                v-model="register.autoTrading.tooOldOrderTimeSeconds"
+            ></v-text-field>
+            <v-text-field
+                label="한번에 주문할 금액을 입력해주세요."
+                v-model="register.autoTrading.orderPrice"
+            ></v-text-field>
 
-<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+            <v-text-field
+                label="계좌 안전 금액을 입력해주세요."
+                v-model="register.autoTrading.accountBalanceLimit"
+            ></v-text-field>
+            <v-select
+                label="키 페어 ID를 선택해주세요."
+                solo
+                :items="user.keyPairList"
+                item-text="pairId"
+                item-value="pairId"
+                v-model="register.autoTrading.keyPairId"
+            ></v-select>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn
+                color="primary"
+                @click="registerAutoTrading(refresh)"
+            > 자동매매 등록
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</v-app>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
 <script type="text/javascript"></script>
 <script>
   var api = axios.create({
@@ -213,10 +350,10 @@
   });
   new Vue({
     el: '#app',
+    vuetify: new Vuetify(),
     data() {
       return {
         user: {
-          id: "",
           keyPairList: [],
           autoTradingList: [],
           backTestingList: []
@@ -234,6 +371,7 @@
       this.register.autoTrading = this.resetAutoTradingRegister();
       this.register.backTesting = this.resetBackTestingRegister();
       this.type = this.resetTypeInfo();
+      this.refresh();
     },
     methods: {
       async refresh() {
@@ -244,6 +382,7 @@
         this.user.keyPairList = await this.getUserKeyList(userId);
         this.user.autoTradingList = await this.getUserAutoTradingList(userId);
         this.user.backTestingList = await this.getUserBackTestingList(userId);
+        this.type = this.resetTypeInfo();
       },
       addKeyInputBox() {
         this.register.keyPair.keyList.push({name: "", value: ""});
@@ -252,29 +391,29 @@
         this.register.keyPair.keyList.splice(index, 1);
       },
       async getUserKeyList(userId) {
-        const response = await api.get("/user/" + userId + "/key/pair", this.headers());
+        const response = await api.get("/user/" + userId + "/key/pair");
         return response.data.body;
       },
       async getUserAutoTradingList(userId) {
-        const response = await api.get("/user/" + userId + "/autotrading", this.headers());
+        const response = await api.get("/user/" + userId + "/autotrading");
         return response.data.body;
       },
       async getUserBackTestingList(userId) {
-        const response = await api.get("/user/" + userId + "/backtesting", this.headers());
+        const response = await api.get("/user/" + userId + "/backtesting");
         return response.data.body;
       },
       async deleteUserPairKey(pairKeyId, callback) {
-        const response = await api.delete("/key/pair/" + pairKeyId, this.headers());
+        const response = await api.delete("/key/pair/" + pairKeyId);
         callback();
         return response.data.body;
       },
       async startAutoTrading(autoTradingProcessorId, callback) {
-        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/start", {}, this.headers());
+        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/start", {});
         callback();
         return response.data.body;
       },
       async stopAutoTrading(autoTradingProcessorId, callback) {
-        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/stop", {}, this.headers());
+        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/stop", {});
         callback();
         return response.data.body;
       },
@@ -282,7 +421,7 @@
         if (!confirm("자동매매가 종료되고, 목록에서 제거됩니다. \n 종료하시겠습니까?")) {
           return;
         }
-        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/terminate", {}, this.headers());
+        const response = await api.post("/autotrading/" + autoTradingProcessorId + "/terminate", {});
         callback();
         return response.data.body;
       },
@@ -292,38 +431,29 @@
           keyList: this.register.keyPair.keyList
         };
 
-        const response = await api.post("/key/pair", body, this.headers());
+        const response = await api.post("/key/pair", body);
         this.register.keyPair = this.resetKeyRegister();
         callback();
         return response.data.body;
       },
       async registerAutoTrading(callback) {
         const body = this.register.autoTrading;
-        const response = await api.post("/autotrading/register", body, this.headers());
+        const response = await api.post("/autotrading/register", body);
         this.register.autoTrading = this.resetAutoTradingRegister();
         callback();
         return response.data.body;
       },
       async registerBackTesting(processorId, start, end, callback) {
-        if (!confirm("해당 프로세스에 대해 백테스팅을 실행하시겠습니까?")) {
-          return;
-        }
         const body = {
           autoTradingProcessorId: processorId,
           start: start,
           end: end
         };
 
-        const response = await api.post("/backtesting", body, this.headers());
+        const response = await api.post("/backtesting", body);
         this.register.backTesting = this.resetBackTestingRegister();
         callback();
         return response.data.body;
-      },
-      toggleKeyRegisterUI() {
-        this.register.keyPair.isVisible = !this.register.keyPair.isVisible;
-      },
-      toggleAutoTradingRegisterUI() {
-        this.register.autoTrading.isVisible = !this.register.autoTrading.isVisible;
       },
       toggleBackTestingRegisterUI(autoTradingProcessorId) {
         this.register.backTesting.autoTradingProcessorId = autoTradingProcessorId;
@@ -331,7 +461,6 @@
       },
       resetKeyRegister() {
         return {
-          isVisible: false,
           coinExchangeType: "",
           keyList: [
             {
@@ -343,7 +472,6 @@
       },
       resetAutoTradingRegister() {
         return {
-          isVisible: false,
           title: "",
           coinType: "",
           coinExchangeType: "",
@@ -371,21 +499,9 @@
         }
       },
       async resetTypeInfo() {
-        const response = await api.get("/type", this.headers());
+        const response = await api.get("/type");
         this.type = response.data.body;
       },
-      headers() {
-        const userId = this.user.id;
-        if (!userId) {
-          alert("사용자ID를 입력해주세요.");
-          return;
-        }
-        return {
-          headers: {
-            "userId": this.user.id
-          }
-        };
-      }
     },
   });
 </script>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" th:href="@{favicon.ico(v=2)}"/>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <title>Login</title>
+</head>
+<body>
+<v-app id="app">
+  <v-main>
+    <v-container fluid fill-height>
+      <v-layout align-center justify-center>
+        <v-flex xs12 sm8 md4>
+          <v-card class="elevation-12">
+            <v-toolbar dark color="primary">
+              <v-toolbar-title>Login form</v-toolbar-title>
+            </v-toolbar>
+            <v-card-text>
+              <v-form ref='form' action="/login" method="post">
+                <v-text-field
+                    prepend-icon="person"
+                    name="userId"
+                    label="Login"
+                    type="text"
+                    @keyup.enter="login()"
+                ></v-text-field>
+                <v-text-field
+                    id="password"
+                    prepend-icon="lock"
+                    name="password"
+                    label="Password"
+                    type="password"
+                    @keyup.enter="login()"
+                ></v-text-field>
+              </v-form>
+            </v-card-text>
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn color="primary" @click="login()">Login</v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-flex>
+      </v-layout>
+    </v-container>
+  </v-main>
+</v-app>
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
+<script type="text/javascript"></script>
+<script>
+  var api = axios.create({
+    timeout: 5000,
+  });
+  new Vue({
+    el: '#app',
+    vuetify: new Vuetify(),
+    data() {
+      return {}
+    },
+    async created() {
+    },
+    methods: {
+      async login() {
+        this.$refs.form.$el.submit();
+      },
+    },
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
* 배포할때 githubAction slack 메세지 불필요한거 제거

* 키페어ID를 <select>로 받도록하여 편의성 개선시킴

* vuetify 관련 cdn 추가

* 로그인 부분을 vuetify로 간단하게 전환

* index.html vuetify 사용을 위해 v-app 태그 적용

* 임시 콘솔 로그인 컴포넌트 작성

* 로그인 페이지를 별도로 생성

* login.html 로그인 요청 보낼수 있도록 수정

* spring security 사용하여 로그인 로직 구현

* 로그인 할때 아이디 파라미터를 username으로 사용

* username -> userId로 파라미터명 바꾸고, 로그인 성공 핸들러를 추가

* userId를 http header가 아니라 로그인 session에서 얻도록 수정

* header에 userId 포함하지 않도록 수정

* login.html 타이틀 수정

* index.html 헤더 생성

* logout 버튼 바탕색 제거

* 키 리스트, 자동매매 리스트 vuetify 래핑

* ConsoleController의 type 정보 알려주는 api 스펙 변경

* 키 등록 컴포넌트 vuetify 래핑

* 자동 매매 등록  v-card로 래핑

* 자동 매매 등록 vuetify로 래핑

* 불필요 메소드 제거

* 대쉬 보드 문구 수정

* 대시보드 그리드 시스템 수정

* 대시보드 그리드 시스템 오류 수정2

* 자동 매매 리스트에서 내용이 긴 항목은 collapse 적용

* 세부 설정 json pretty 출력되도록 수정

* 백 테스팅 모달창 생성

* 헤더 색 primary로 수정

Co-authored-by: DingDongDeng <etea583@naver.com>