### PR TITLE
매수 조건 고도화 및 백테스팅 오류 수정

### DIFF
--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/backtesting/context/BackTestingTradingTermCalculator.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/backtesting/context/BackTestingTradingTermCalculator.java
@@ -1,0 +1,45 @@
+package com.dingdongdeng.coinautotrading.trading.backtesting.context;
+
+import com.dingdongdeng.coinautotrading.common.type.CandleUnit;
+import com.dingdongdeng.coinautotrading.trading.exchange.common.model.ExchangeCandles.Candle;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BackTestingTradingTermCalculator {
+
+    private final CandleUnit candleUnit;
+    private List<Candle> candleList = new ArrayList<>();
+
+    public void add(Candle currentCandle) {
+        if (Objects.isNull(currentCandle)) {
+            return;
+        }
+
+        if (candleList.size() > candleUnit.getSize()) {
+            candleList.remove(0);
+        }
+        candleList.add(currentCandle);
+    }
+
+    public double getCandleAccTradePrice(LocalDateTime from, LocalDateTime to) {
+        return this.getByBetweenTime(from, to).stream().mapToDouble(Candle::getCandleAccTradePrice).sum();
+    }
+
+    public double getCandleAccTradeVolume(LocalDateTime from, LocalDateTime to) {
+        return this.getByBetweenTime(from, to).stream().mapToDouble(Candle::getCandleAccTradeVolume).sum();
+    }
+
+    private List<Candle> getByBetweenTime(LocalDateTime from, LocalDateTime to) {
+        return this.candleList.stream()
+            .filter(candle -> {
+                LocalDateTime now = candle.getCandleDateTimeKst();
+                // from < current <= to
+                return now.isAfter(from) && (now.isBefore(to) || now.isEqual(to));
+            })
+            .toList();
+    }
+}

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/exchange/common/model/ExchangeCandles.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/exchange/common/model/ExchangeCandles.java
@@ -18,7 +18,7 @@ public class ExchangeCandles {
     private CoinExchangeType coinExchangeType;
     private CoinType coinType;
     private CandleUnit candleUnit; // 분 단위(유닛)
-    private List<Candle> candleList;
+    private List<Candle> candleList; // 가장 마지막 캔들은 현재 시점에 대한 캔들
 
 
     @ToString

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/core/ResistanceTradingStrategyCore.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/core/ResistanceTradingStrategyCore.java
@@ -5,11 +5,13 @@ import com.dingdongdeng.coinautotrading.common.type.OrderType;
 import com.dingdongdeng.coinautotrading.common.type.PriceType;
 import com.dingdongdeng.coinautotrading.common.type.TradingTerm;
 import com.dingdongdeng.coinautotrading.trading.common.context.TradingTimeContext;
+import com.dingdongdeng.coinautotrading.trading.exchange.common.model.ExchangeCandles;
 import com.dingdongdeng.coinautotrading.trading.index.Index;
 import com.dingdongdeng.coinautotrading.trading.strategy.StrategyCore;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.SpotTradingInfo;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.SpotTradingResult;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.StrategyCoreParam;
+import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingInfo;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingResultPack;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.TradingTask;
 import com.dingdongdeng.coinautotrading.trading.strategy.model.type.TradingTag;
@@ -121,7 +123,7 @@ public class ResistanceTradingStrategyCore implements StrategyCore<SpotTradingIn
         /*
          * 조건을 만족하면 매수 주문
          */
-        if (isBuyOrderTiming(tradingInfo.getCurrentPrice(), tradingResultPack, index)) {
+        if (isBuyOrderTiming(tradingInfo.getCurrentPrice(), tradingInfo, tradingResultPack, index)) {
 
             double currentPrice = tradingInfo.getCurrentPrice();
             double volume = getVolumeForBuy(currentPrice, tradingResultPack);
@@ -176,11 +178,9 @@ public class ResistanceTradingStrategyCore implements StrategyCore<SpotTradingIn
         return true;
     }
 
-    private boolean isBuyOrderTiming(double currentPrice, TradingResultPack<SpotTradingResult> tradingResultPack, Index index) {
+    private boolean isBuyOrderTiming(double currentPrice, TradingInfo tradingInfo, TradingResultPack<SpotTradingResult> tradingResultPack, Index index) {
         List<SpotTradingResult> buyTradingResultList = tradingResultPack.getBuyTradingResultList();
         boolean isExsistBuyOrder = !buyTradingResultList.isEmpty();
-        boolean isResistancePrice = index.getResistancePriceList().stream()
-            .anyMatch(resistancePrice -> currentPrice < resistancePrice * (1 + param.getResistancePriceBuffer()) && currentPrice > resistancePrice);
 
         // 하락 추세라면
         if (index.getMacd().getCurrent() < 1000 || index.getRsi() < 0.30) {
@@ -196,7 +196,7 @@ public class ResistanceTradingStrategyCore implements StrategyCore<SpotTradingIn
 
         // 지지받고 있지 않다면
         if (!isResistancePrice) {
-            log.info("[매수 조건] 지지 받고 있지 않음, resistancePriceList={}, currentPrice={}", index.getResistancePriceList(), currentPrice);
+            log.info("[매수 조건] 지지 받고 있지 않음, resistancePriceList={}, averagePrice={}", index.getResistancePriceList(), averagePrice);
             return false;
         }
 

--- a/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/core/ResistanceTradingStrategyCoreParam.java
+++ b/src/main/java/com/dingdongdeng/coinautotrading/trading/strategy/core/ResistanceTradingStrategyCoreParam.java
@@ -18,7 +18,7 @@ public class ResistanceTradingStrategyCoreParam implements StrategyCoreParam {
     @GuideMessage("최초 주문할 금액을 입력해주세요. ex) 40000")
     private double initOrderPrice; // 처음에 주문할 금액
 
-    @GuideMessage("저항선 버퍼(0.002을 설정하면 저항선 기준으로 0.5%의 버퍼를 둠)")
+    @GuideMessage("저항선 버퍼(0.002을 설정하면 저항선 기준으로 0.2%의 버퍼를 둠)")
     private double resistancePriceBuffer;
 
     @GuideMessage("계좌 안전 금액을 입력해주세요.")

--- a/src/test/java/com/dingdongdeng/coinautotrading/trading/index/IndexCalculatorTest.java
+++ b/src/test/java/com/dingdongdeng/coinautotrading/trading/index/IndexCalculatorTest.java
@@ -118,6 +118,22 @@ class IndexCalculatorTest {
         assertEquals(macd.getCurrent(), 3399.4713725503443);
     }
 
+    @Test
+    public void MACD_계산_테스트2() {
+        // given
+        CoinType coinType = CoinType.ETHEREUM;
+        TradingTerm tradingTerm = TradingTerm.SCALPING_240M;
+        LocalDateTime now = LocalDateTime.of(2022, 12, 24, 13, 0, 10);
+        ExchangeCandles candles = getExchangeCandles(now, tradingTerm, coinType, keyPairId);
+
+        // when
+        Macd macd = calculator.getMACD(candles);
+
+        // then
+        log.info("result : {}", macd);
+        assertEquals(2205.1025093942594, macd.getCurrent());
+    }
+
     private ExchangeCandles getExchangeCandles(LocalDateTime now, TradingTerm tradingTerm, CoinType coinType, String keyPairId) {
         List<CandleResponse> response = upbitClient.getMinuteCandle(
             CandleRequest.builder()


### PR DESCRIPTION
불필요 주석 제거

매수 조건 수정

지지선 필터 로직 주석처리

캔들 리스트에 현재 캔들도 추가

주석 추가

macd TC 추가

macd 로직 리팩토링

오타 수정

가상 캔들 만들때 캔들 개수 200개 안넘도록 수정

백테스팅에서 가상 캔들 만들때 누적 거래금액,거래량 좀 더 정확하게 계산 하도록 수정(초기화 로직이 미흡)